### PR TITLE
Removed facetoface_instance from master

### DIFF
--- a/classes/observer.php
+++ b/classes/observer.php
@@ -62,22 +62,4 @@ class mod_facetoface_observer {
         }
     }
 
-    /**
-     * Observer for \core\event\course_module_created event.
-     *
-     * @param \core\event\course_module_created $event
-     * @return void
-     */
-    public static function course_module_created(\core\event\course_module_created $event) {
-        global $CFG;
-
-        if ($event->other['modulename'] === 'facetoface') {
-
-            // Include the Face-to-Face library to make use of the facetoface_instance_created function.
-            require_once($CFG->dirroot . '/mod/facetoface/lib.php');
-
-            $facetoface = $event->get_record_snapshot('facetoface', $event->other['instanceid']);
-            facetoface_instance_created($event->get_context(), $forum);
-        }
-    }
 }


### PR DESCRIPTION
This was removed in 2.8 to fix the issue but was not done in master.
