### PR TITLE
Fixed calendar events, now compatible with Moodle 3.2 to 3.5.

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,12 @@
+3.2.2 (2018-05-30):
+Bug fixes:
+- Site, course and user calendar events now work properly. They no longer all end up being course events.
+- Creating, updating and deleting Face-to-face sessions no longer leave orphan and duplicate events in the events table.
+- Deleting an instance of Face-to-face from a course no longer leave orphan calendar events in the events table.
+
+Improvements:
+- Now compatible with Moodle 3.2 to 3.5
+
 2.3.1 (2014-03-06):
 Bug fixes:
 - fix SQL group by

--- a/version.php
+++ b/version.php
@@ -30,8 +30,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2017090101;
+$plugin->version   = 2018053000;
 $plugin->requires  = 2016120502;  // Requires this Moodle version.
-$plugin->release   = '3.2.1 (Build: 2017090100)';
+$plugin->release   = '3.2.2 (Build: 2018053000)';
 $plugin->component = 'mod_facetoface';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
3.2.2 (2018-05-30):
Bug fixes:
- Site, course and user calendar events now work properly. They no longer all end up being course events.
- Creating, updating and deleting Face-to-face sessions no longer leave orphan and duplicate events in the events table.
- Deleting a Face-to-face activity from a course no longer leave orphan calendar events in the events table.

Improvements:
- Now compatible with Moodle 3.2 to 3.5