### PR TITLE
Add rich text editor for confirmation messages

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -1,177 +1,178 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/facetoface/db" VERSION="20170530" COMMENT="XMLDB file for Moodle mod/facetoface"
+<XMLDB PATH="mod/facetoface/db" VERSION="20210615" COMMENT="XMLDB file for Moodle mod/facetoface"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
-  <TABLES>
-    <TABLE NAME="facetoface" COMMENT="Each facetoface activity has an entry here">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true" COMMENT="id of the table, please edit me"/>
-        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="intro" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="intro"/>
-        <FIELD NAME="introformat" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="introformat"/>
-        <FIELD NAME="thirdparty" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="email address of a third party involved in this activity"/>
-        <FIELD NAME="thirdpartywaitlist" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Set to 1 if the third party wants to receive signups/cancellations about wait-listed sessions, 0 otherwise."/>
-        <FIELD NAME="display" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="confirmationsubject" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Subject line for the confirmation emails"/>
-        <FIELD NAME="confirmationinstrmngr" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Contents of confirmation emails sent to instructors and managers"/>
-        <FIELD NAME="confirmationmessage" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Contents of confirmation emails sent to students"/>
-        <FIELD NAME="waitlistedsubject" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Subject of the email sent when the user is on a wait-list"/>
-        <FIELD NAME="waitlistedmessage" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Contents of the email sent when a user is on a wait-list"/>
-        <FIELD NAME="cancellationsubject" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Subject of the emails sent when users get out of an activity"/>
-        <FIELD NAME="cancellationinstrmngr" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Contents of the emails sent to instructors and managers when students get out of an activity"/>
-        <FIELD NAME="cancellationmessage" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Contents of the emails sent to users who got out of an activity"/>
-        <FIELD NAME="remindersubject" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Subject of reminder emails sent before an activity"/>
-        <FIELD NAME="reminderinstrmngr" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Contents of the emails sent to instructors and managers when a user is reminded of an upcoming activity"/>
-        <FIELD NAME="remindermessage" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Contents of the emails sent to users reminding them of an upcoming activity"/>
-        <FIELD NAME="reminderperiod" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="The number of days before the activity that reminders will be sent.  A value of 0 disables the reminder."/>
-        <FIELD NAME="requestsubject" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Subject of booking request emails"/>
-        <FIELD NAME="requestinstrmngr" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Contents of the emails sent to instructors and managers when a user requests a activity booking"/>
-        <FIELD NAME="requestmessage" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Contents of the emails sent to users requesting an activity booking"/>
-        <FIELD NAME="timecreated" TYPE="int" LENGTH="20" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="timemodified" TYPE="int" LENGTH="20" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="shortname" TYPE="char" LENGTH="32" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="showoncalendar" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
-        <FIELD NAME="approvalreqd" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="usercalentry" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
-        <FIELD NAME="allowcancellationsdefault" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="Primary key for facetoface"/>
-      </KEYS>
-      <INDEXES>
-        <INDEX NAME="course" UNIQUE="false" FIELDS="course"/>
-      </INDEXES>
-    </TABLE>
-    <TABLE NAME="facetoface_session_roles" COMMENT="Users with a trainer role in a facetoface session">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true" COMMENT="id of the table"/>
-        <FIELD NAME="sessionid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="roleid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-        <KEY NAME="sessionid" TYPE="foreign" FIELDS="sessionid" REFTABLE="facetoface_sessions" REFFIELDS="id"/>
-      </KEYS>
-    </TABLE>
-    <TABLE NAME="facetoface_sessions" COMMENT="A given facetoface activity may be given at different times and places">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true" COMMENT="id of the table, please edit me"/>
-        <FIELD NAME="facetoface" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="ID of the facetoface activity this session is for"/>
-        <FIELD NAME="capacity" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Number of students who can enroll in this session. A value of 0 means unlimited."/>
-        <FIELD NAME="allowoverbook" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Flag to turn on waitlisting of signups over capacity."/>
-        <FIELD NAME="details" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Extra information about this session"/>
-        <FIELD NAME="datetimeknown" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="A value of 0 means that the date and time are unknown whereas a value of 1 means that both are known."/>
-        <FIELD NAME="duration" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Total duration (in minutes) of the session.  A session may be split across multiple dates, this is the total."/>
-        <FIELD NAME="normalcost" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="The normal (non-discounted) cost of the session"/>
-        <FIELD NAME="discountcost" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Discounted cost of the event"/>
-        <FIELD NAME="allowcancellations" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
-        <FIELD NAME="timecreated" TYPE="int" LENGTH="20" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="timemodified" TYPE="int" LENGTH="20" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="primary key of the table, please edit me"/>
-        <KEY NAME="facetoface" TYPE="foreign" FIELDS="facetoface" REFTABLE="facetoface" REFFIELDS="id"/>
-      </KEYS>
-    </TABLE>
-    <TABLE NAME="facetoface_sessions_dates" COMMENT="The dates and times for each session.  Sessions can be set over multiple days or blocks of time.">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true" COMMENT="id of the table, please edit me"/>
-        <FIELD NAME="sessionid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="timestart" TYPE="int" LENGTH="20" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="timefinish" TYPE="int" LENGTH="20" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="primary key of the table, please edit me"/>
-        <KEY NAME="sessionid" TYPE="foreign" FIELDS="sessionid" REFTABLE="facetoface_sessions" REFFIELDS="id"/>
-      </KEYS>
-    </TABLE>
-    <TABLE NAME="facetoface_signups" COMMENT="User/session signups">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="sessionid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="mailedreminder" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="discountcode" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="notificationtype" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="primary key of the table, please edit me"/>
-        <KEY NAME="sessionid" TYPE="foreign" FIELDS="sessionid" REFTABLE="facetoface_sessions" REFFIELDS="id"/>
-      </KEYS>
-    </TABLE>
-    <TABLE NAME="facetoface_signups_status" COMMENT="User/session signup status">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="signupid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="statuscode" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="superceded" TYPE="int" LENGTH="1" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="grade" TYPE="number" LENGTH="10" NOTNULL="false" SEQUENCE="false" DECIMALS="5"/>
-        <FIELD NAME="note" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="advice" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="createdby" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="primary key of the table, please edit me"/>
-        <KEY NAME="signupid" TYPE="foreign" FIELDS="signupid" REFTABLE="facetoface_signups" REFFIELDS="id"/>
-      </KEYS>
-    </TABLE>
-    <TABLE NAME="facetoface_session_field" COMMENT="Definitions of custom info fields for Face-to-face session">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="shortname" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="type" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="possiblevalues" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="CSV list of allowed values"/>
-        <FIELD NAME="required" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Whether or not this field is mandatory"/>
-        <FIELD NAME="defaultvalue" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="isfilter" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Whether or not this field is a filter on the Training Calendar"/>
-        <FIELD NAME="showinsummary" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Whether or not to show this field in attendance exports and lists of sessions"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-      <INDEXES>
-        <INDEX NAME="ind_session_field_unique" UNIQUE="true" FIELDS="shortname" COMMENT="Guarantees that all short names are actually unique"/>
-      </INDEXES>
-    </TABLE>
-    <TABLE NAME="facetoface_session_data" COMMENT="Contents of custom info fields for Face-to-face session">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="fieldid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="ID in facetoface_session_field"/>
-        <FIELD NAME="sessionid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="ID in facetoface_sessions"/>
-        <FIELD NAME="data" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="Contents"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-    </TABLE>
-    <TABLE NAME="facetoface_notice" COMMENT="Site-wide notices shown on the Training Calendar">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="Name displayed to admins in list of notices"/>
-        <FIELD NAME="text" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Text shown to users on the Training Calendar"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-    </TABLE>
-    <TABLE NAME="facetoface_notice_data" COMMENT="Custom field filters for site notices">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="fieldid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="ID from the facetoface_session_field table"/>
-        <FIELD NAME="noticeid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="ID from the facetoface_notice table"/>
-        <FIELD NAME="data" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="Value of the custom field required for the notice to be shown on the training calendar"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-      <INDEXES>
-        <INDEX NAME="facetoface_notice_date_fieldid" UNIQUE="false" FIELDS="fieldid"/>
-      </INDEXES>
-    </TABLE>
-  </TABLES>
+    <TABLES>
+        <TABLE NAME="facetoface" COMMENT="Each facetoface activity has an entry here">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true" COMMENT="id of the table, please edit me"/>
+                <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="intro" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="intro"/>
+                <FIELD NAME="introformat" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="introformat"/>
+                <FIELD NAME="thirdparty" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="email address of a third party involved in this activity"/>
+                <FIELD NAME="thirdpartywaitlist" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Set to 1 if the third party wants to receive signups/cancellations about wait-listed sessions, 0 otherwise."/>
+                <FIELD NAME="display" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="confirmationsubject" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Subject line for the confirmation emails"/>
+                <FIELD NAME="confirmationinstrmngr" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Contents of confirmation emails sent to instructors and managers"/>
+                <FIELD NAME="confirmationmessage" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Contents of confirmation emails sent to students"/>
+                <FIELD NAME="confirmationmessageformat" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="confirmationmessageformat"/>
+                <FIELD NAME="waitlistedsubject" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Subject of the email sent when the user is on a wait-list"/>
+                <FIELD NAME="waitlistedmessage" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Contents of the email sent when a user is on a wait-list"/>
+                <FIELD NAME="cancellationsubject" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Subject of the emails sent when users get out of an activity"/>
+                <FIELD NAME="cancellationinstrmngr" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Contents of the emails sent to instructors and managers when students get out of an activity"/>
+                <FIELD NAME="cancellationmessage" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Contents of the emails sent to users who got out of an activity"/>
+                <FIELD NAME="remindersubject" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Subject of reminder emails sent before an activity"/>
+                <FIELD NAME="reminderinstrmngr" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Contents of the emails sent to instructors and managers when a user is reminded of an upcoming activity"/>
+                <FIELD NAME="remindermessage" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Contents of the emails sent to users reminding them of an upcoming activity"/>
+                <FIELD NAME="reminderperiod" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="The number of days before the activity that reminders will be sent.  A value of 0 disables the reminder."/>
+                <FIELD NAME="requestsubject" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Subject of booking request emails"/>
+                <FIELD NAME="requestinstrmngr" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Contents of the emails sent to instructors and managers when a user requests a activity booking"/>
+                <FIELD NAME="requestmessage" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Contents of the emails sent to users requesting an activity booking"/>
+                <FIELD NAME="timecreated" TYPE="int" LENGTH="20" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="timemodified" TYPE="int" LENGTH="20" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="shortname" TYPE="char" LENGTH="32" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="showoncalendar" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
+                <FIELD NAME="approvalreqd" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="usercalentry" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
+                <FIELD NAME="allowcancellationsdefault" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="Primary key for facetoface"/>
+            </KEYS>
+            <INDEXES>
+                <INDEX NAME="course" UNIQUE="false" FIELDS="course"/>
+            </INDEXES>
+        </TABLE>
+        <TABLE NAME="facetoface_session_roles" COMMENT="Users with a trainer role in a facetoface session">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true" COMMENT="id of the table"/>
+                <FIELD NAME="sessionid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+                <FIELD NAME="roleid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+                <KEY NAME="sessionid" TYPE="foreign" FIELDS="sessionid" REFTABLE="facetoface_sessions" REFFIELDS="id"/>
+            </KEYS>
+        </TABLE>
+        <TABLE NAME="facetoface_sessions" COMMENT="A given facetoface activity may be given at different times and places">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true" COMMENT="id of the table, please edit me"/>
+                <FIELD NAME="facetoface" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="ID of the facetoface activity this session is for"/>
+                <FIELD NAME="capacity" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Number of students who can enroll in this session. A value of 0 means unlimited."/>
+                <FIELD NAME="allowoverbook" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Flag to turn on waitlisting of signups over capacity."/>
+                <FIELD NAME="details" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Extra information about this session"/>
+                <FIELD NAME="datetimeknown" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="A value of 0 means that the date and time are unknown whereas a value of 1 means that both are known."/>
+                <FIELD NAME="duration" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Total duration (in minutes) of the session.  A session may be split across multiple dates, this is the total."/>
+                <FIELD NAME="normalcost" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="The normal (non-discounted) cost of the session"/>
+                <FIELD NAME="discountcost" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Discounted cost of the event"/>
+                <FIELD NAME="allowcancellations" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
+                <FIELD NAME="timecreated" TYPE="int" LENGTH="20" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="timemodified" TYPE="int" LENGTH="20" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="primary key of the table, please edit me"/>
+                <KEY NAME="facetoface" TYPE="foreign" FIELDS="facetoface" REFTABLE="facetoface" REFFIELDS="id"/>
+            </KEYS>
+        </TABLE>
+        <TABLE NAME="facetoface_sessions_dates" COMMENT="The dates and times for each session.  Sessions can be set over multiple days or blocks of time.">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true" COMMENT="id of the table, please edit me"/>
+                <FIELD NAME="sessionid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="timestart" TYPE="int" LENGTH="20" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="timefinish" TYPE="int" LENGTH="20" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="primary key of the table, please edit me"/>
+                <KEY NAME="sessionid" TYPE="foreign" FIELDS="sessionid" REFTABLE="facetoface_sessions" REFFIELDS="id"/>
+            </KEYS>
+        </TABLE>
+        <TABLE NAME="facetoface_signups" COMMENT="User/session signups">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="sessionid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+                <FIELD NAME="mailedreminder" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+                <FIELD NAME="discountcode" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="notificationtype" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="primary key of the table, please edit me"/>
+                <KEY NAME="sessionid" TYPE="foreign" FIELDS="sessionid" REFTABLE="facetoface_sessions" REFFIELDS="id"/>
+            </KEYS>
+        </TABLE>
+        <TABLE NAME="facetoface_signups_status" COMMENT="User/session signup status">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="signupid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+                <FIELD NAME="statuscode" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+                <FIELD NAME="superceded" TYPE="int" LENGTH="1" NOTNULL="true" SEQUENCE="false"/>
+                <FIELD NAME="grade" TYPE="number" LENGTH="10" NOTNULL="false" SEQUENCE="false" DECIMALS="5"/>
+                <FIELD NAME="note" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="advice" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="createdby" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+                <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="primary key of the table, please edit me"/>
+                <KEY NAME="signupid" TYPE="foreign" FIELDS="signupid" REFTABLE="facetoface_signups" REFFIELDS="id"/>
+            </KEYS>
+        </TABLE>
+        <TABLE NAME="facetoface_session_field" COMMENT="Definitions of custom info fields for Face-to-face session">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="shortname" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="type" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="possiblevalues" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="CSV list of allowed values"/>
+                <FIELD NAME="required" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Whether or not this field is mandatory"/>
+                <FIELD NAME="defaultvalue" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="isfilter" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Whether or not this field is a filter on the Training Calendar"/>
+                <FIELD NAME="showinsummary" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Whether or not to show this field in attendance exports and lists of sessions"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+            <INDEXES>
+                <INDEX NAME="ind_session_field_unique" UNIQUE="true" FIELDS="shortname" COMMENT="Guarantees that all short names are actually unique"/>
+            </INDEXES>
+        </TABLE>
+        <TABLE NAME="facetoface_session_data" COMMENT="Contents of custom info fields for Face-to-face session">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="fieldid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="ID in facetoface_session_field"/>
+                <FIELD NAME="sessionid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="ID in facetoface_sessions"/>
+                <FIELD NAME="data" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="Contents"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+        </TABLE>
+        <TABLE NAME="facetoface_notice" COMMENT="Site-wide notices shown on the Training Calendar">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="Name displayed to admins in list of notices"/>
+                <FIELD NAME="text" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Text shown to users on the Training Calendar"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+        </TABLE>
+        <TABLE NAME="facetoface_notice_data" COMMENT="Custom field filters for site notices">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="fieldid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="ID from the facetoface_session_field table"/>
+                <FIELD NAME="noticeid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="ID from the facetoface_notice table"/>
+                <FIELD NAME="data" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="Value of the custom field required for the notice to be shown on the training calendar"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+            <INDEXES>
+                <INDEX NAME="facetoface_notice_date_fieldid" UNIQUE="false" FIELDS="fieldid"/>
+            </INDEXES>
+        </TABLE>
+    </TABLES>
 </XMLDB>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -46,8 +46,8 @@ function facetoface_send_admin_upgrade_msg($data) {
 
     $table = new html_table();
     $table->head = array('Custom field ID',
-                         'Custom field original shortname',
-                         'Custom field new shortname');
+        'Custom field original shortname',
+        'Custom field new shortname');
     $table->data = $data;
     $table->align = array ('center', 'center', 'center');
 
@@ -745,6 +745,21 @@ function xmldb_facetoface_upgrade($oldversion=0) {
 
         // Facetoface savepoint reached.
         upgrade_mod_savepoint(true, 2017053000, 'facetoface');
+    }
+
+    if ($oldversion < 2020080401) {
+
+        // Define field confirmationmessageformat to be added to facetoface.
+        $table = new xmldb_table('facetoface');
+        $field = new xmldb_field('confirmationmessageformat', XMLDB_TYPE_INTEGER, '2', null, XMLDB_NOTNULL, null, '0', 'confirmationmessage');
+
+        // Conditionally launch add field confirmationmessageformat.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Facetoface savepoint reached.
+        upgrade_mod_savepoint(true, 2020080401, 'facetoface');
     }
 
     return $result;

--- a/lang/en/facetoface.php
+++ b/lang/en/facetoface.php
@@ -410,6 +410,7 @@ To re-schedule your booking you need to cancel this booking and then re-book a n
 
 You will receive a reminder [reminderperiod] business days before this course.
 ';
+$string['setting:defaultconfirmationmessagedefault2'] = '<p><b>Thank you for signing up!</b>';
 $string['setting:defaultconfirmationsubject'] = 'Default subject line for confirmation emails.';
 $string['setting:defaultconfirmationsubject_caption'] = 'Confirmation subject';
 $string['setting:defaultconfirmationsubjectdefault'] = 'Course booking confirmation: [facetofacename], [starttime]-[finishtime], [sessiondate]';

--- a/lib.php
+++ b/lib.php
@@ -314,6 +314,7 @@ function facetoface_add_instance($facetoface) {
     global $DB;
 
     $facetoface->timemodified = time();
+    $facetoface->confirmationmessage = $facetoface->confirmationmessage['text'];
     facetoface_fix_settings($facetoface);
     if ($facetoface->id = $DB->insert_record('facetoface', $facetoface)) {
         facetoface_grade_item_update($facetoface);
@@ -340,6 +341,7 @@ function facetoface_update_instance($facetoface, $instanceflag = true) {
     if ($instanceflag) {
         $facetoface->id = $facetoface->instance;
     }
+    $facetoface->confirmationmessage = $facetoface->confirmationmessage['text'];
 
     facetoface_fix_settings($facetoface);
     if ($return = $DB->update_record('facetoface', $facetoface)) {
@@ -1984,7 +1986,7 @@ function facetoface_user_cancel($session, $userid=false, $forcecancel=false, &$e
  * @returns string Error message (or empty string if successful)
  */
 function facetoface_send_notice($postsubject, $posttext, $posttextmgrheading,
-                                $notificationtype, $facetoface, $session, $userid) {
+                                $notificationtype, $facetoface, $session, $userid,$htmlmessage) {
     global $CFG, $DB;
 
     $user = $DB->get_record('user', array('id' => $userid));
@@ -2035,7 +2037,8 @@ function facetoface_send_notice($postsubject, $posttext, $posttextmgrheading,
                                                           $user, $session, $session->id);
                 $body = facetoface_email_substitutions($posttext, $facetoface->name, $facetoface->reminderperiod,
                                                        $user, $session, $session->id);
-                $htmlbody = ''; // TODO.
+                 $htmlmessage = facetoface_email_substitutions($posttext, $facetoface->name, $facetoface->reminderperiod, $user, $session, $session->id);
+                $htmlbody = $htmlmessage;
                 $icalattachments[] = array('filename' => $filename, 'subject' => $subject,
                                            'body' => $body, 'htmlbody' => $htmlbody);
             }
@@ -2048,7 +2051,8 @@ function facetoface_send_notice($postsubject, $posttext, $posttextmgrheading,
                                                       $user, $session, $session->id);
             $body = facetoface_email_substitutions($posttext, $facetoface->name, $facetoface->reminderperiod,
                                                    $user, $session, $session->id);
-            $htmlbody = ''; // FIXME.
+             $htmlmessage = facetoface_email_substitutions($posttext, $facetoface->name, $facetoface->reminderperiod, $user, $session, $session->id);
+            $htmlbody = $htmlmessage; 
             $icalattachments[] = array('filename' => $filename, 'subject' => $subject,
                                        'body' => $body, 'htmlbody' => $htmlbody);
         }
@@ -2154,8 +2158,11 @@ function facetoface_send_confirmation_notice($facetoface, $session, $userid, $no
     // Set invite bit.
     $notificationtype |= MDL_F2F_INVITE;
 
+    //Set HTML Body
+    $htmlmessage = $facetoface->confirmationmessage;
+
     return facetoface_send_notice($postsubject, $posttext, $posttextmgrheading,
-                                  $notificationtype, $facetoface, $session, $userid);
+                                  $notificationtype, $facetoface, $session, $userid,$htmlmessage);
 }
 
 /**

--- a/lib.php
+++ b/lib.php
@@ -1983,10 +1983,11 @@ function facetoface_user_cancel($session, $userid=false, $forcecancel=false, &$e
  * @param class $facetoface record from the facetoface table
  * @param class $session record from the facetoface_sessions table
  * @param integer $userid ID of the recipient of the email
+ * @param string $htmlmessage Html message
  * @returns string Error message (or empty string if successful)
  */
 function facetoface_send_notice($postsubject, $posttext, $posttextmgrheading,
-                                $notificationtype, $facetoface, $session, $userid,$htmlmessage) {
+                                $notificationtype, $facetoface, $session, $userid, $htmlmessage) {
     global $CFG, $DB;
 
     $user = $DB->get_record('user', array('id' => $userid));
@@ -2037,7 +2038,7 @@ function facetoface_send_notice($postsubject, $posttext, $posttextmgrheading,
                                                           $user, $session, $session->id);
                 $body = facetoface_email_substitutions($posttext, format_string($facetoface->name), $facetoface->reminderperiod,
                                                        $user, $session, $session->id);
-                 $htmlmessage = facetoface_email_substitutions($posttext, $facetoface->name, $facetoface->reminderperiod, $user, $session, $session->id);
+                $htmlmessage = facetoface_email_substitutions($posttext, $facetoface->name, $facetoface->reminderperiod, $user, $session, $session->id);
                 $htmlbody = $htmlmessage;
                 $icalattachments[] = array('filename' => $filename, 'subject' => $subject,
                                            'body' => $body, 'htmlbody' => $htmlbody);
@@ -2051,8 +2052,8 @@ function facetoface_send_notice($postsubject, $posttext, $posttextmgrheading,
                                                       $user, $session, $session->id);
             $body = facetoface_email_substitutions($posttext, format_string($facetoface->name), $facetoface->reminderperiod,
                                                    $user, $session, $session->id);
-             $htmlmessage = facetoface_email_substitutions($posttext, $facetoface->name, $facetoface->reminderperiod, $user, $session, $session->id);
-            $htmlbody = $htmlmessage; 
+            $htmlmessage = facetoface_email_substitutions($posttext, $facetoface->name, $facetoface->reminderperiod, $user, $session, $session->id);
+            $htmlbody = $htmlmessage;
             $icalattachments[] = array('filename' => $filename, 'subject' => $subject,
                                        'body' => $body, 'htmlbody' => $htmlbody);
         }
@@ -2158,7 +2159,7 @@ function facetoface_send_confirmation_notice($facetoface, $session, $userid, $no
     // Set invite bit.
     $notificationtype |= MDL_F2F_INVITE;
 
-    //Set HTML Body
+    // Set HTML Body.
     $htmlmessage = $facetoface->confirmationmessage;
 
     return facetoface_send_notice($postsubject, $posttext, $posttextmgrheading,

--- a/mod_form.php
+++ b/mod_form.php
@@ -122,8 +122,10 @@ class mod_facetoface_mod_form extends moodleform_mod {
         $mform->setType('confirmationsubject', PARAM_TEXT);
         $mform->setDefault('confirmationsubject', get_string('setting:defaultconfirmationsubjectdefault', 'facetoface'));
 
-        $mform->addElement('textarea', 'confirmationmessage', get_string('email:message', 'facetoface'), 'wrap="virtual" rows="15" cols="70"');
-        $mform->setDefault('confirmationmessage', get_string('setting:defaultconfirmationmessagedefault', 'facetoface'));
+        $editoroptions = ['trusttext' => true];
+        $mform->addElement('editor', 'confirmationmessage', get_string('email:message', 'facetoface'), null, $editoroptions);
+        $mform->setType('confirmationmessage', PARAM_RAW);
+        $mform->setDefault('confirmationmessage', get_string('setting:defaultconfirmationmessagedefault2', 'facetoface'));
 
         $mform->addElement('checkbox', 'emailmanagerconfirmation', get_string('emailmanager', 'facetoface'));
         $mform->addHelpButton('emailmanagerconfirmation', 'emailmanagerconfirmation', 'facetoface');

--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2020080400;
+$plugin->version   = 2020080401;
 $plugin->requires  = 2017111300;  // Requires 3.4.
 $plugin->release   = '3.9.1';
 $plugin->component = 'mod_facetoface';


### PR DESCRIPTION
Fix: #55 

Hello! 
We have replaced the plain 'text area' with a rich text editor that allows you to add html formatted messages for the confirmation.
Currently, HTML Messages can be created & updated for the confirmation message. These messages are also sent out as rich text to the users. 

We would like a review on the above and assistance with one area we couldn't figure out: 

1. With using the rich text editor, we were not able to set a default value for the editor
2. Retrieve an existing value from the DB to display in the editor when a user tries to update the confirmation message at a later stage.

If there are any suggestions on accomplishing the above, we would love to work to fix those further and replicate it for the other types of messages (waitlist, cancellation). 