### PR TITLE
Add user without course enrollment

### DIFF
--- a/editattendees.php
+++ b/editattendees.php
@@ -88,7 +88,11 @@ if (optional_param('add', false, PARAM_BOOL) && confirm_sesskey()) {
                 $user = $DB->get_record('user', array('id' => $adduser));
                 // Make sure that the user is enroled in the course.
                 if (!is_enrolled($context, $user)) {
-                    if (!enrol_try_internal_enrol($course->id, $user->id)) {
+                    $defaultroleid = null;
+                    // Get default role ID for manual enrollment.
+                    $conditions = array ('courseid' => $course->id, 'enrol' => 'manual');
+                    $defaultroleid = $DB->get_field('enrol', 'roleid', $conditions, IGNORE_MISSING);
+                    if (!enrol_try_internal_enrol($course->id, $user->id, $defaultroleid)) {
                         $errors[] = get_string('error:enrolmentfailed', 'facetoface', fullname($user));
                         $errors[] = get_string('error:addattendee', 'facetoface', fullname($user));
                         continue; // Don't sign the user up.


### PR DESCRIPTION
Fix: #25
-When a user without course enrollment is added to a F2F session, default role of manual enrollment is assigned to user.