### PR TITLE
Custom Session Fields Language Filter Fix

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -3827,13 +3827,13 @@ function facetoface_add_customfields_to_form(&$mform, $customfields, $alloptiona
 
         switch ($field->type) {
             case CUSTOMFIELD_TYPE_TEXT:
-                $mform->addElement('text', $fieldname, $field->name);
+                $mform->addElement('text', $fieldname, format_string($field->name));
                 break;
             case CUSTOMFIELD_TYPE_SELECT:
-                $mform->addElement('select', $fieldname, $field->name, $options);
+                $mform->addElement('select', $fieldname, format_string($field->name), $options);
                 break;
             case CUSTOMFIELD_TYPE_MULTISELECT:
-                $select = &$mform->addElement('select', $fieldname, $field->name, $options);
+                $select = &$mform->addElement('select', $fieldname, format_string($field->name), $options);
                 $select->setMultiple(true);
                 break;
             default:


### PR DESCRIPTION
Hello,

There are some minor fixes for custom session fields language filter. _filter_string_ is applied to _$field->name_.

Please let me know in case of any questions.

Thanks,
Sameer