### PR TITLE
Fix-63: Fix deprecated get_all_user_name_fields() in Moodle 3.11.

### DIFF
--- a/classes/session_form.php
+++ b/classes/session_form.php
@@ -164,7 +164,7 @@ class mod_facetoface_session_form extends moodleform {
                 $rolename = $rolename->name;
 
                 // Attempt to load users with this role in this course.
-                $usernamefields = get_all_user_name_fields(true);
+                $usernamefields = facetoface_get_all_user_name_fields(true);
                 $rs = $DB->get_recordset_sql("
                     SELECT
                         u.id,

--- a/editattendees.php
+++ b/editattendees.php
@@ -100,7 +100,7 @@ if (optional_param('add', false, PARAM_BOOL) && confirm_sesskey()) {
                 }
             }
 
-            $usernamefields = get_all_user_name_fields(true);
+            $usernamefields = facetoface_get_all_user_name_fields(true);
             if (facetoface_get_user_submissions($facetoface->id, $adduser)) {
                 $erruser = $DB->get_record('user', array('id' => $adduser), "id, {$usernamefields}");
                 $errors[] = get_string('error:addalreadysignedupattendee', 'facetoface', fullname($erruser));
@@ -146,7 +146,7 @@ if (optional_param('remove', false, PARAM_BOOL) && confirm_sesskey()) {
                 }
             } else {
                 $errors[] = $cancelerr;
-                $usernamefields = get_all_user_name_fields(true);
+                $usernamefields = facetoface_get_all_user_name_fields(true);
                 $erruser = $DB->get_record('user', array('id' => $removeuser), "id, {$usernamefields}");
                 $errors[] = get_string('error:removeattendee', 'facetoface', fullname($erruser));
             }
@@ -216,7 +216,7 @@ $out .= html_writer::table($table);
 
 // Get all signed up non-attendees.
 $nonattendees = 0;
-$usernamefields = get_all_user_name_fields(true, 'u');
+$usernamefields = facetoface_get_all_user_name_fields(true, 'u');
 $nonattendeesrs = $DB->get_recordset_sql(
      "SELECT
             u.id,

--- a/lib.php
+++ b/lib.php
@@ -1106,7 +1106,7 @@ function facetoface_get_grade($userid, $courseid, $facetofaceid) {
 function facetoface_get_attendees($sessionid) {
     global $CFG, $DB;
 
-    $usernamefields = get_all_user_name_fields(true, 'u');
+    $usernamefields = facetoface_get_all_user_name_fields(true, 'u');
     $records = $DB->get_records_sql("
         SELECT u.id, {$usernamefields},
             u.email,
@@ -3719,7 +3719,7 @@ function facetoface_get_trainer_roles() {
 function facetoface_get_trainers($sessionid, $roleid = null) {
     global $CFG, $DB;
 
-    $usernamefields = get_all_user_name_fields(true, 'u');
+    $usernamefields = facetoface_get_all_user_name_fields(true, 'u');
     $sql = "
         SELECT
             u.id,
@@ -3860,7 +3860,7 @@ function facetoface_get_cancellations($sessionid) {
     global $CFG, $DB;
 
     $fullname = $DB->sql_fullname('u.firstname', 'u.lastname');
-    $usernamefields = get_all_user_name_fields(true, 'u');
+    $usernamefields = facetoface_get_all_user_name_fields(true, 'u');
     $instatus = array(MDL_F2F_STATUS_BOOKED, MDL_F2F_STATUS_WAITLISTED, MDL_F2F_STATUS_REQUESTED);
     list($insql, $inparams) = $DB->get_in_or_equal($instatus);
 
@@ -3917,7 +3917,7 @@ function facetoface_get_requests($sessionid) {
     global $CFG, $DB;
 
     $fullname = $DB->sql_fullname('u.firstname', 'u.lastname');
-    $usernamefields = get_all_user_name_fields(true);
+    $usernamefields = facetoface_get_all_user_name_fields(true, 'u');
 
     $params = array($sessionid, MDL_F2F_STATUS_REQUESTED);
 
@@ -3944,7 +3944,7 @@ function facetoface_get_declines($sessionid) {
     global $CFG, $DB;
 
     $fullname = $DB->sql_fullname('u.firstname', 'u.lastname');
-    $usernamefields = get_all_user_name_fields(true);
+    $usernamefields = facetoface_get_all_user_name_fields(true, 'u');
 
     $params = array($sessionid, MDL_F2F_STATUS_DECLINED);
 
@@ -3983,6 +3983,26 @@ function facetoface_supports($feature) {
         default:
             return null;
     }
+}
+
+/**
+ * A centralised location for the all name fields. Returns an array / sql string snippet.
+ *
+ * @param bool $returnsql True for an sql select field snippet.
+ * @param string $tableprefix table query prefix to use in front of each field.
+ * @return array|string All name fields.
+ */
+function facetoface_get_all_user_name_fields($returnsql = false, $tableprefix = null) {
+    global $CFG;
+
+    $ret = \core_user\fields::get_name_fields();
+    if (!empty($tableprefix)) {
+        $ret = substr_replace($ret, $tableprefix . '.', 0, 0);
+    }
+    if ($returnsql) {
+        $ret = join(',', $ret);
+    }
+    return $ret;
 }
 
 /*


### PR DESCRIPTION
Hi @danmarsden ,

This pull request addresses the issue described in #63 relating to the function get_all_user_name_fields() which is deprecated as of Moodle 3.11.

Note: The fix for this plugin continues to maintain backwards compatibility with previous versions of Moodle.

Please let me know if you have any questions or concerns.

Best regards,

Michael