### PR TITLE
Allow bulk adding to all sessions

### DIFF
--- a/editattendees.php
+++ b/editattendees.php
@@ -194,7 +194,7 @@ if ($facetoface->signuptype == MOD_FACETOFACE_SIGNUP_MULTIPLE) {
     $content = html_writer::checkbox(
         'addtoallsessions',
         1,
-        $addtoallsessions,
+        0,
         get_string('addtoallsessions', 'facetoface'),
         array('id' => 'addtoallsessions')
     );
@@ -204,7 +204,7 @@ if ($facetoface->signuptype == MOD_FACETOFACE_SIGNUP_MULTIPLE) {
     $table->data[] = new html_table_row(array($cell));
 }
 
-$content = html_writer::checkbox('suppressemail', 1, $suppressemail, get_string('suppressemail', 'facetoface'),
+$content = html_writer::checkbox('suppressemail', 1, 0, get_string('suppressemail', 'facetoface'),
     array('id' => 'suppressemail'));
 $content .= $OUTPUT->help_icon('suppressemail', 'facetoface');
 $cell = new html_table_cell($content);

--- a/editattendees.php
+++ b/editattendees.php
@@ -33,13 +33,14 @@ require_once('lib.php');
 
 define('MAX_USERS_PER_PAGE', 5000);
 
-$s              = required_param('s', PARAM_INT); // Facetoface session ID.
-$add            = optional_param('add', 0, PARAM_BOOL);
-$remove         = optional_param('remove', 0, PARAM_BOOL);
-$showall        = optional_param('showall', 0, PARAM_BOOL);
-$searchtext     = optional_param('searchtext', '', PARAM_TEXT); // Search string.
-$suppressemail  = optional_param('suppressemail', false, PARAM_BOOL); // Send email notifications.
-$previoussearch = optional_param('previoussearch', 0, PARAM_BOOL);
+$s                 = required_param('s', PARAM_INT); // Facetoface session ID.
+$add               = optional_param('add', 0, PARAM_BOOL);
+$remove            = optional_param('remove', 0, PARAM_BOOL);
+$showall           = optional_param('showall', 0, PARAM_BOOL);
+$searchtext        = optional_param('searchtext', '', PARAM_TEXT); // Search string.
+$suppressemail     = optional_param('suppressemail', false, PARAM_BOOL); // Send email notifications.
+$previoussearch    = optional_param('previoussearch', 0, PARAM_BOOL);
+$addtoallsessions  = optional_param('addtoallsessions', 0, PARAM_BOOL);
 $backtoallsessions = optional_param('backtoallsessions', 0, PARAM_INT); // Facetoface activity to go back to.
 
 if (!$session = facetoface_get_session($s)) {
@@ -105,20 +106,30 @@ if (optional_param('add', false, PARAM_BOOL) && confirm_sesskey()) {
                 $erruser = $DB->get_record('user', array('id' => $adduser), "id, {$usernamefields}");
                 $errors[] = get_string('error:addalreadysignedupattendee', 'facetoface', fullname($erruser));
             } else {
-                if (!facetoface_session_has_capacity($session, $context)) {
-                    $errors[] = get_string('full', 'facetoface');
-                    break; // No point in trying to add other people.
-                }
-                // Check if we are waitlisting or booking.
-                if ($session->datetimeknown) {
-                    $status = MDL_F2F_STATUS_BOOKED;
-                } else {
-                    $status = MDL_F2F_STATUS_WAITLISTED;
-                }
-                if (!facetoface_user_signup($session, $facetoface, $course, '', MDL_F2F_BOTH,
-                $status, $adduser, !$suppressemail)) {
-                    $erruser = $DB->get_record('user', array('id' => $adduser), "id, {$usernamefields}");
-                    $errors[] = get_string('error:addattendee', 'facetoface', fullname($erruser));
+                $now = time();
+                $addtofuturesessions = $addtoallsessions && $facetoface->signuptype == MOD_FACETOFACE_SIGNUP_MULTIPLE;
+                $futuresessions = array_filter(
+                    facetoface_get_sessions($facetoface->id),
+                    fn(stdClass $s): bool => !empty(array_filter($s->sessiondates, fn(stdClass $d): bool => $d->timestart > $now))
+                );
+                $sessions = $addtofuturesessions ? $futuresessions : [$session];
+
+                foreach ($sessions as $session) {
+                    if (!facetoface_session_has_capacity($session, $context)) {
+                        $errors[] = get_string('full', 'facetoface');
+                        break; // No point in trying to add other people.
+                    }
+                    // Check if we are waitlisting or booking.
+                    if ($session->datetimeknown) {
+                        $status = MDL_F2F_STATUS_BOOKED;
+                    } else {
+                        $status = MDL_F2F_STATUS_WAITLISTED;
+                    }
+                    if (!facetoface_user_signup($session, $facetoface, $course, '', MDL_F2F_BOTH,
+                            $status, $adduser, !$suppressemail)) {
+                        $erruser = $DB->get_record('user', array('id' => $adduser), "id, {$usernamefields}");
+                        $errors[] = get_string('error:addattendee', 'facetoface', fullname($erruser));
+                    }
                 }
             }
         }
@@ -211,6 +222,20 @@ $cell = new html_table_cell($content);
 $cell->attributes['id'] = 'backcell';
 $cell->attributes['colspan'] = '3';
 $table->data[] = new html_table_row(array($cell));
+
+if ($facetoface->signuptype == MOD_FACETOFACE_SIGNUP_MULTIPLE) {
+    $content = html_writer::checkbox(
+        'addtoallsessions',
+        1,
+        $addtoallsessions,
+        get_string('addtoallsessions', 'facetoface'),
+        array('id' => 'addtoallsessions')
+    );
+    $content .= $OUTPUT->help_icon('addtoallsessions', 'facetoface');
+    $cell = new html_table_cell($content);
+    $cell->attributes['colspan'] = '3';
+    $table->data[] = new html_table_row(array($cell));
+}
 
 $out .= html_writer::table($table);
 

--- a/editattendees.php
+++ b/editattendees.php
@@ -189,6 +189,29 @@ $out .= html_writer::empty_tag('input', array('type' => 'hidden', 'name' => "ses
 $table = new html_table();
 $table->attributes['class'] = "generaltable generalbox boxaligncenter";
 $cells = array();
+
+if ($facetoface->signuptype == MOD_FACETOFACE_SIGNUP_MULTIPLE) {
+    $content = html_writer::checkbox(
+        'addtoallsessions',
+        1,
+        $addtoallsessions,
+        get_string('addtoallsessions', 'facetoface'),
+        array('id' => 'addtoallsessions')
+    );
+    $content .= $OUTPUT->help_icon('addtoallsessions', 'facetoface');
+    $cell = new html_table_cell($content);
+    $cell->attributes['colspan'] = '3';
+    $table->data[] = new html_table_row(array($cell));
+}
+
+$content = html_writer::checkbox('suppressemail', 1, $suppressemail, get_string('suppressemail', 'facetoface'),
+    array('id' => 'suppressemail'));
+$content .= $OUTPUT->help_icon('suppressemail', 'facetoface');
+$cell = new html_table_cell($content);
+$cell->attributes['id'] = 'backcell';
+$cell->attributes['colspan'] = '3';
+$table->data[] = new html_table_row(array($cell));
+
 $content = html_writer::start_tag('p') . html_writer::tag('label', get_string('attendees', 'facetoface'),
         array('for' => 'removeselect')) . html_writer::end_tag('p');
 $content .= $existinguserselector->display(true);
@@ -211,27 +234,6 @@ $cell = new html_table_cell($content);
 $cell->attributes['id'] = 'potentialcell';
 $cells[] = $cell;
 $table->data[] = new html_table_row($cells);
-$content = html_writer::checkbox('suppressemail', 1, $suppressemail, get_string('suppressemail', 'facetoface'),
-    array('id' => 'suppressemail'));
-$content .= $OUTPUT->help_icon('suppressemail', 'facetoface');
-$cell = new html_table_cell($content);
-$cell->attributes['id'] = 'backcell';
-$cell->attributes['colspan'] = '3';
-$table->data[] = new html_table_row(array($cell));
-
-if ($facetoface->signuptype == MOD_FACETOFACE_SIGNUP_MULTIPLE) {
-    $content = html_writer::checkbox(
-        'addtoallsessions',
-        1,
-        $addtoallsessions,
-        get_string('addtoallsessions', 'facetoface'),
-        array('id' => 'addtoallsessions')
-    );
-    $content .= $OUTPUT->help_icon('addtoallsessions', 'facetoface');
-    $cell = new html_table_cell($content);
-    $cell->attributes['colspan'] = '3';
-    $table->data[] = new html_table_row(array($cell));
-}
 
 $out .= html_writer::table($table);
 

--- a/editattendees.php
+++ b/editattendees.php
@@ -108,11 +108,7 @@ if (optional_param('add', false, PARAM_BOOL) && confirm_sesskey()) {
             } else {
                 $now = time();
                 $addtofuturesessions = $addtoallsessions && $facetoface->signuptype == MOD_FACETOFACE_SIGNUP_MULTIPLE;
-                $futuresessions = array_filter(
-                    facetoface_get_sessions($facetoface->id),
-                    fn(stdClass $s): bool => !empty(array_filter($s->sessiondates, fn(stdClass $d): bool => $d->timestart > $now))
-                );
-                $sessions = $addtofuturesessions ? $futuresessions : [$session];
+                $sessions = $addtofuturesessions ? facetoface_get_future_sessions($facetoface->id) : [$session];
 
                 foreach ($sessions as $session) {
                     if (!facetoface_session_has_capacity($session, $context)) {

--- a/lang/en/facetoface.php
+++ b/lang/en/facetoface.php
@@ -794,5 +794,5 @@ $string['eventupdatemanageremailfailed'] = 'Update manager email (FAILED)';
 $string['eventupdatesession'] = 'Session updated';
 $string['eventupdatesessionfailed'] = 'Session update (FAILED)';
 $string['waitliststatus'] = 'You have a place on the waitlist of the following session';
-$string['addtoallsessions'] = 'Add the selected users to all (upcoming) sessions';
-$string['addtoallsessions_help'] = 'When selected, users will be added to all upcoming (i.e., not finished) sessions within the face to face activity';
+$string['addtoallsessions'] = 'Add users to all (upcoming) sessions';
+$string['addtoallsessions_help'] = 'Use this option if you want to add users to all upcoming Face-to-Face sessions. When this uption is toggled, the selected users will be added to this session and all other future sessions in the activity.';

--- a/lang/en/facetoface.php
+++ b/lang/en/facetoface.php
@@ -794,3 +794,5 @@ $string['eventupdatemanageremailfailed'] = 'Update manager email (FAILED)';
 $string['eventupdatesession'] = 'Session updated';
 $string['eventupdatesessionfailed'] = 'Session update (FAILED)';
 $string['waitliststatus'] = 'You have a place on the waitlist of the following session';
+$string['addtoallsessions'] = 'Add the selected users to all (upcoming) sessions';
+$string['addtoallsessions_help'] = 'When selected, users will be added to all upcoming (i.e., not finished) sessions within the face to face activity';

--- a/lib.php
+++ b/lib.php
@@ -1087,6 +1087,21 @@ function facetoface_get_sessions($facetofaceid, $location='') {
 }
 
 /**
+ * Get all sessions that are in the future.
+ *
+ * @param int $id Face to face ID.
+ *
+ * @return array Array of Face to face sessions.
+ */
+function facetoface_get_future_sessions(int $id): array {
+    $now = time();
+    return array_filter(
+        facetoface_get_sessions($id),
+        fn (stdClass $s): bool => !empty(array_filter($s->sessiondates, fn (stdClass $d): bool => $d->timestart > $now))
+    );
+}
+
+/**
  * Get a grade for the given user from the gradebook.
  *
  * @param integer $userid       ID of the user

--- a/signup.php
+++ b/signup.php
@@ -128,7 +128,13 @@ if ($fromform = $mform->get_data()) { // Form submitted.
     if ($isbulksignup) {
         $error = '';
         $message = get_string('bookingcompleted', 'facetoface');
-        foreach (facetoface_get_sessions($facetoface->id) as $session) {
+        $now = time();
+        $futuresessions = array_filter(
+            facetoface_get_sessions($facetoface->id),
+            fn (stdClass $s): bool => !empty(array_filter($s->sessiondates, fn (stdClass $d): bool => $d->timestart > $now))
+        );
+
+        foreach ($futuresessions as $session) {
             if (!facetoface_session_has_capacity($session, $context) && (!$session->allowoverbook)) {
                 $error = html_writer::empty_tag('br') . html_writer::empty_tag('br') . get_string('somesessionsfull', 'facetoface');
                 continue;

--- a/signup.php
+++ b/signup.php
@@ -128,13 +128,8 @@ if ($fromform = $mform->get_data()) { // Form submitted.
     if ($isbulksignup) {
         $error = '';
         $message = get_string('bookingcompleted', 'facetoface');
-        $now = time();
-        $futuresessions = array_filter(
-            facetoface_get_sessions($facetoface->id),
-            fn (stdClass $s): bool => !empty(array_filter($s->sessiondates, fn (stdClass $d): bool => $d->timestart > $now))
-        );
 
-        foreach ($futuresessions as $session) {
+        foreach (facetoface_get_future_sessions($facetoface->id) as $session) {
             if (!facetoface_session_has_capacity($session, $context) && (!$session->allowoverbook)) {
                 $error = html_writer::empty_tag('br') . html_writer::empty_tag('br') . get_string('somesessionsfull', 'facetoface');
                 continue;

--- a/view.php
+++ b/view.php
@@ -215,7 +215,7 @@ function print_session_list($courseid, $facetoface, $location) {
     // Upcoming sessions.
     echo $OUTPUT->heading(get_string('upcomingsessions', 'facetoface'));
 
-    if ($sessions && $bulksignup) {
+    if (!empty($upcomingarray) && $bulksignup) {
         $firstsession = $sessions[array_keys($sessions)[0]];
         $signupforstreamlink = html_writer::link(
             'signup.php?s=' . $firstsession->id . '&backtoallsessions=' . $session->facetoface,


### PR DESCRIPTION
**Prerequisites**: A course with some students enrolled

# Testing instructions
1. Create a face to face activity with default settings:
2. Press the "Save and display" button
3. Click the "Add a new session" link
4. Set "Session date/time known" to "Yes"
5. Set the start time and finish time to a date in the past
6. Press the "Save changes" button
7. Click the "Add a new session" link
8. Set "Session date/time known" to "Yes"
9. Set the start time and finish time to a date in the past
10. Press the "Add a new date" button
11. Set the start time and finish time of the new date to a date in the future
12. Press the "Save changes" button
13. Click the "Add a new session" link
14. Set "Session date/time known" to "Yes"
15. Set the start time and finish time to a date in the future
16. Press the "Save changes" button
17. Click the "Attendees" link for the session under the "Upcoming sessions" heading
18. Click the "Add/remove attendees" link
19. **Verify** there is **no** checkbox with the text "Add the selected users to all (upcoming) sessions"
20. Select a user and press the "Add" button
21. Click the "Go back" link
22. Click the "Go back" link
23. **Verify** that the capacity for the session under the "Upcoming sessions" header is now 1/10
24. **Verify** all other sessions show 0/10
25. Edit the face to face activity, changing the following settings:
    * "Signup type": "Multiple"
    * "Multiple signup method": "Per activity"
26. Press the "Save and display" button
27. Click the "Attendees" link for the session under "Upcoming sessions"
28. Click the "Add/remove attendees" link
29. **Verify** there **is** a checkbox with the text "Add the selected users to all (upcoming) sessions" (don't check it)
30. Select a user and press the "Add" button
31. Click the "Go back" link
32. Click the "Go back" link
33. **Verify** that the capacity for the session under the "Upcoming sessions" header is now 2/10
34. **Verify** all other sessions show 0/10
35. Click the "Attendees" link for the session under "Upcoming sessions"
36. Click the "Add/remove attendees" link
37. Check the "Add the selected users to all (upcoming) sessions" checkbox
38. Select a user and press the "Add" button
39. Click the "Go back" link
40. Click the "Go back" link
41. **Verify** that the capacity for the session under the "Upcoming sessions" header is now 3/10
42. **Verify** that the capacity for the session that has a date in the future is now 1/10 (even though this session is under the "Previous sessions" heading (this is possibly a pre-existing bug))
43. **Verify** the last remaining session still shows 0/10