### PR TITLE
Allow adding users to multiple sessions from the bulk add page when signup type is "multiple"

### DIFF
--- a/editattendees.php
+++ b/editattendees.php
@@ -102,7 +102,7 @@ if (optional_param('add', false, PARAM_BOOL) && confirm_sesskey()) {
             }
 
             $usernamefields = facetoface_get_all_user_name_fields(true);
-            if (facetoface_get_user_submissions($facetoface->id, $adduser)) {
+            if (facetoface_get_user_submissions($facetoface->id, $adduser) && $facetoface->signuptype != MOD_FACETOFACE_SIGNUP_MULTIPLE) {
                 $erruser = $DB->get_record('user', array('id' => $adduser), "id, {$usernamefields}");
                 $errors[] = get_string('error:addalreadysignedupattendee', 'facetoface', fullname($erruser));
             } else {


### PR DESCRIPTION
Testing:

1. Create a f2f activity with "Signup type" set to "Multiple"
2. Create two sessions within the f2f activity
3. View the f2f activity and click the "Attendees" link for the first session
4. Click the "Add/remove attendees" link
5. Add a user to the session
6. Go back to the main f2f activity page and click the "Attendees" link for the second session
7. Click the "Add/remove attendees" link
8. Attempt to add the same user from step 5
9. **Verify** the user is in both sessions
10. Create a f2f activity with "Signup type" set to "Single"
11. Create two sessions within the f2f activity
12. View the f2f activity and click the "Attendees" link for the first session
13. Click the "Add/remove attendees" link
14. Add a user to the session
15. Go back to the main f2f activity page and click the "Attendees" link for the second session
16. Click the "Add/remove attendees" link
17. Attempt to add the same user from step 5
18. **Verify** an error is displayed and the user is not added to the second session
