### PR TITLE
#137 Plugin setting session_roles in plugin namespace not being used.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -3871,15 +3871,16 @@ function facetoface_update_trainers($sessionid, $form) {
  * @return array
  */
 function facetoface_get_trainer_roles() {
-    global $CFG, $DB;
+    global $DB;
 
     // Check that roles have been selected.
-    if (empty($CFG->facetoface_session_roles)) {
+    $config = get_config('facetoface');
+    if (empty($config->session_roles)) {
         return false;
     }
 
     // Parse roles.
-    $cleanroles = clean_param($CFG->facetoface_session_roles, PARAM_SEQUENCE);
+    $cleanroles = clean_param($config->session_roles, PARAM_SEQUENCE);
     $roles = explode(',', $cleanroles);
     list($rolesql, $params) = $DB->get_in_or_equal($roles);
 


### PR DESCRIPTION
In issue https://github.com/catalyst/moodle-mod_facetoface/issues/116 the plugin settings were moved from the global namespace to the plugin namespace.

When checking for available settings roles it is checking the old $CFG location meaning any saved results are not loaded.

Simple/quick fix attached.

Thanks.

Josh