### PR TITLE
[#147] Pass context to user selectors

### DIFF
--- a/editattendees.php
+++ b/editattendees.php
@@ -71,8 +71,8 @@ $strfacetoface = get_string('modulename', 'facetoface');
 $errors = array();
 
 // Get the user_selector we will need.
-$potentialuserselector = new facetoface_candidate_selector('addselect', array('sessionid' => $session->id, 'courseid' => $course->id));
-$existinguserselector = new facetoface_existing_selector('removeselect', array('sessionid' => $session->id));
+$potentialuserselector = new facetoface_candidate_selector('addselect', array('sessionid' => $session->id, 'courseid' => $course->id, 'accesscontext' => $context));
+$existinguserselector = new facetoface_existing_selector('removeselect', array('sessionid' => $session->id, 'accesscontext' => $context));
 
 // Process incoming user assignments.
 if (optional_param('add', false, PARAM_BOOL) && confirm_sesskey()) {


### PR DESCRIPTION
Closes #147 

Simple fix for issue, just passing in the correct context. Note the context is course context, not course module context, because this appears to be what the rest of the page is using.

**Testing**
Logged in as user with `moodle/site:viewuseridentity` in course context, but not system context. `showuseridentity` config has email selected to show. On the attendees sign up page.

**Before (no emails shown):**

![image](https://github.com/catalyst/moodle-mod_facetoface/assets/17095477/0dce15e6-df2d-4c07-9b34-bf100757179a)

**After (emails shown - good):**

![image](https://github.com/catalyst/moodle-mod_facetoface/assets/17095477/24ee6d4f-31f4-4808-909b-3523f73aa86c)

### TODO

- [x] Cherry pick to other branches -> https://github.com/catalyst/moodle-mod_facetoface/pull/149

