### PR TITLE
Fix #54 - remove event name limit

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -65,7 +65,6 @@ define('CUSTOMFIELD_TYPE_SELECT',      1);
 define('CUSTOMFIELD_TYPE_MULTISELECT', 2);
 
 // Calendar-related constants.
-define('CALENDAR_MAX_NAME_LENGTH', 15);
 define('F2F_CAL_NONE',   0);
 define('F2F_CAL_COURSE', 1);
 define('F2F_CAL_SITE',   2);
@@ -3509,7 +3508,7 @@ function facetoface_add_session_to_calendar($session, $facetoface, $calendartype
 
     $shortname = $facetoface->shortname;
     if (empty($shortname)) {
-        $shortname = core_text::substr($facetoface->name, 0, CALENDAR_MAX_NAME_LENGTH);
+        $shortname = $facetoface->name;
     }
 
     $result = true;


### PR DESCRIPTION
As stated in #54 

> AFAIK technically mdl_event.name is a longtext and module name which is used to build the event name is a varchar(255).
> I know that you can use "shortname" if you want to display a specific (and length unlimited) event name but it forces teachers to do double entry if they only want the module name to be displayed completely.
> 
> IMO truncate should be done on display only (and is correctly handle by the calendar) and not during event creation.