### PR TITLE
Bulk upload suppress emails

### DIFF
--- a/classes/booking_manager.php
+++ b/classes/booking_manager.php
@@ -53,6 +53,9 @@ class booking_manager {
     /** @var bool Whether or not the bookings are loaded from a file. */
     private $usefile = true;
 
+    /** @var bool When true, confirmation emails are not sent. */
+    private $suppressemail = false;
+
     /**
      * Constructor for the booking manager.
      * @param int $f The facetoface module ID.
@@ -357,7 +360,7 @@ class booking_manager {
                         $this->transform_notification_type($entry->notificationtype),
                         $statuscode,
                         $user->id,
-                        true
+                        !$this->suppressemail,
                     );
 
                     continue;
@@ -389,5 +392,12 @@ class booking_manager {
         }
 
         return true;
+    }
+
+    /**
+     * Stops confirmation emails from being sent
+     */
+    public function suppress_email() {
+        $this->suppressemail = true;
     }
 }

--- a/classes/form/confirm_bookings_form.php
+++ b/classes/form/confirm_bookings_form.php
@@ -41,8 +41,13 @@ class confirm_bookings_form extends moodleform {
         global $OUTPUT;
 
         $mform = $this->_form;
-        $fileid = $this->_customdata['fileid'] ?: 0;
-        $f = $this->_customdata['f'] ?: 0;
+        $fileid = $this->_customdata['fileid'] ?? 0;
+        $f = $this->_customdata['f'] ?? 0;
+
+        // Suppress email checkbox.
+        $mform->addElement('advcheckbox', 'suppressemail', get_string('suppressemail', 'facetoface'), '', [], [0, 1]);
+        $mform->addHelpButton('suppressemail', 'suppressemail', 'facetoface');
+        $mform->setType('supressemail', PARAM_BOOL);
 
         // The facetoface module ID.
         $mform->addElement('hidden', 'f');

--- a/classes/form/upload_bookings_form.php
+++ b/classes/form/upload_bookings_form.php
@@ -19,6 +19,9 @@ namespace mod_facetoface\form;
 use moodle_url;
 use html_writer;
 
+defined('MOODLE_INTERNAL') || die();
+require_once($CFG->dirroot . '/repository/lib.php');
+
 /**
  * Upload bookings form class
  *

--- a/upload.php
+++ b/upload.php
@@ -30,7 +30,6 @@ use core\output\notification;
 use mod_facetoface\form\upload_bookings_form;
 use mod_facetoface\form\confirm_bookings_form;
 use mod_facetoface\booking_manager;
-use mod_facetoface\event\csv_processed;
 
 $f = optional_param('f', 0, PARAM_INT); // The facetoface module ID.
 $fileid = optional_param('fileid', 0, PARAM_INT); // The fileid of the file uploaded.
@@ -54,7 +53,6 @@ $modulecontext = context_module::instance($cm->id);
 require_capability('mod/facetoface:editsessions', $context);
 require_capability('mod/facetoface:uploadbookings', $context);
 
-echo $OUTPUT->header();
 
 // Render form, which should only consist of an upload element.
 if ($validate) {
@@ -99,7 +97,7 @@ if ($validate) {
 
     // Get the options selected by the user at confirm time.
     $confirmdata = (new confirm_bookings_form(null))->get_data();
-    
+
     if (!empty($confirmdata->suppressemail)) {
         $bm->suppress_email();
     }
@@ -116,7 +114,6 @@ if ($validate) {
             'objectid' => $f,
         ];
         $event = \mod_facetoface\event\csv_processed::create($params);
-        $event->add_record_snapshot('facetoface_sessions', $session);
         $event->add_record_snapshot('facetoface', $facetoface);
         $event->trigger();
 
@@ -142,11 +139,12 @@ if ($validate) {
     $heading = get_string('facetoface:uploadbookings', 'facetoface');
 }
 
-$PAGE->set_url(new moodle_url('/mod/facetoface/upload.php', ['courseid' => $courseid, 'cmid' => $cm->id]));
-$PAGE->set_context($context);
+$PAGE->set_url(new moodle_url('/mod/facetoface/upload.php', ['courseid' => $course->id, 'cmid' => $cm->id]));
 $PAGE->set_pagelayout('standard');
 $PAGE->set_title($heading);
 $PAGE->set_heading($heading);
+
+echo $OUTPUT->header();
 
 $mform->display();
 

--- a/upload.php
+++ b/upload.php
@@ -97,6 +97,13 @@ if ($validate) {
     $bm = new booking_manager($f);
     $bm->load_from_file($fileid);
 
+    // Get the options selected by the user at confirm time.
+    $confirmdata = (new confirm_bookings_form(null))->get_data();
+    
+    if (!empty($confirmdata->suppressemail)) {
+        $bm->suppress_email();
+    }
+
     // Validate entries.
     $errors = $bm->validate();
     if (empty($errors)) {

--- a/version.php
+++ b/version.php
@@ -30,8 +30,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024052700;
-$plugin->release   = 2024052700;
+$plugin->version   = 2024070500;
+$plugin->release   = 2024070500;
 $plugin->requires  = 2023100900;  // Requires 4.3.
 $plugin->component = 'mod_facetoface';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
**Changes**

- Adds a checkbox to suppress emails when bulk uploading, to bring it in alignment with the manual assignment page.
- A few fixups to the code that were causing debugging messages:
    - Output before redirect
    - Context being set when it didn't need to be (and was trying to set a different context)
    - Undefined var `$courseid`
    - Undefined var `$session`
    - Removed unused import

**Testing**

- Manual testing - works as expected.
- Also covered by unit tests