### PR TITLE
bugfix: upload csv output order regression

### DIFF
--- a/upload.php
+++ b/upload.php
@@ -71,24 +71,6 @@ if ($validate) {
     // Validate entries.
     $errors = $bm->validate();
 
-    // List out any issues in a table.
-    if (!empty($errors)) {
-        // Print summary statement.
-        echo \core\notification::error(get_string('error:bookingsuploadfileerrorsfound', 'mod_facetoface', count($errors)));
-
-        $table = new html_table();
-        $table->attributes['class'] = 'f2fbookingsuploadlist m-auto generaltable mb-2';
-
-        $table->head[] = get_string('uucsvline', 'tool_uploaduser');
-        $table->head[] = get_string('status');
-        $table->data = $errors;
-
-        echo html_writer::tag('div', html_writer::table($table), ['class' => 'flexible-wrap mb-4']);
-    } else {
-        // Bonus: show a preview/summary for good records (e.g. 40 records will be processed).
-        echo \core\notification::success(get_string('facetoface:uploadreadytoprocess', 'mod_facetoface'));
-    }
-
     // Set form data to allow user to continue and process the uploaded file on their next form submit.
 } else if ($process && $fileid && $f) {
     // Form submitted, and ready for processing -> process.
@@ -145,6 +127,24 @@ $PAGE->set_title($heading);
 $PAGE->set_heading($heading);
 
 echo $OUTPUT->header();
+
+// List out any issues in a table.
+if (!empty($errors)) {
+    // Print summary statement.
+    echo \core\notification::error(get_string('error:bookingsuploadfileerrorsfound', 'mod_facetoface', count($errors)));
+
+    $table = new html_table();
+    $table->attributes['class'] = 'f2fbookingsuploadlist m-auto generaltable mb-2';
+
+    $table->head[] = get_string('uucsvline', 'tool_uploaduser');
+    $table->head[] = get_string('status');
+    $table->data = $errors;
+
+    echo html_writer::tag('div', html_writer::table($table), ['class' => 'flexible-wrap mb-4']);
+} else {
+    // Bonus: show a preview/summary for good records (e.g. 40 records will be processed).
+    echo \core\notification::success(get_string('facetoface:uploadreadytoprocess', 'mod_facetoface'));
+}
 
 $mform->display();
 


### PR DESCRIPTION
- Fixes a small display order regression, which appears if you upload a csv with errors in in.
- Regression caused by https://github.com/catalyst/moodle-mod_facetoface/pull/168

- [x] Cherry-picked to https://github.com/catalyst/moodle-mod_facetoface/pull/171

Before - error output shows before header:

![2024-07-08_14-25](https://github.com/catalyst/moodle-mod_facetoface/assets/17095477/16f02ea0-5d7e-4228-8a70-ee52d22f53e3)


After - error output shows inline with mform as expected:

![2024-07-08_14-32](https://github.com/catalyst/moodle-mod_facetoface/assets/17095477/bb5f5f2c-cfe0-42ba-9010-17e0f111483a)
