### PR TITLE
bugfix: show upload validation notification only when necessary

### DIFF
--- a/upload.php
+++ b/upload.php
@@ -129,7 +129,7 @@ $PAGE->set_heading($heading);
 echo $OUTPUT->header();
 
 // List out any issues in a table.
-if (!empty($errors)) {
+if ($validate && !empty($errors)) {
     // Print summary statement.
     echo \core\notification::error(get_string('error:bookingsuploadfileerrorsfound', 'mod_facetoface', count($errors)));
 
@@ -141,7 +141,9 @@ if (!empty($errors)) {
     $table->data = $errors;
 
     echo html_writer::tag('div', html_writer::table($table), ['class' => 'flexible-wrap mb-4']);
-} else {
+}
+
+if ($validate && empty($errors)) {
     // Bonus: show a preview/summary for good records (e.g. 40 records will be processed).
     echo \core\notification::success(get_string('facetoface:uploadreadytoprocess', 'mod_facetoface'));
 }


### PR DESCRIPTION
Fixes a tiny regression introduced by https://github.com/catalyst/moodle-mod_facetoface/pull/170 where the successful validation/upload notification would show when the user has not even uploaded yet

- [x] Cherry pick to `MOODLE_400_STABLE` https://github.com/catalyst/moodle-mod_facetoface/pull/173