### PR TITLE
feat: suppress cancel emails in bulk upload

### DIFF
--- a/classes/booking_manager.php
+++ b/classes/booking_manager.php
@@ -335,7 +335,7 @@ class booking_manager {
                 if (facetoface_user_cancel($session, $user->id, true, $cancelerr)) {
                     // Notify the user of the cancellation if the session hasn't started yet.
                     $timenow = time();
-                    if (!facetoface_has_session_started($session, $timenow)) {
+                    if (!facetoface_has_session_started($session, $timenow) && !$this->suppressemail) {
                         facetoface_send_cancellation_notice($this->facetoface, $session, $user->id);
                     }
                 } else {

--- a/tests/upload_test.php
+++ b/tests/upload_test.php
@@ -550,10 +550,20 @@ class upload_test extends \advanced_testcase {
      */
     public static function email_suppression_provider(): array {
         return [
-            'no suppression' => [
+            'no suppression, booked' => [
+                'status' => 'booked',
                 'shouldsuppress' => false,
             ],
-            'suppressed emails' => [
+            'suppressed emails, booked' => [
+                'status' => 'booked',
+                'shouldsuppress' => true,
+            ],
+            'no suppression, cancel' => [
+                'status' => 'cancelled',
+                'shouldsuppress' => false,
+            ],
+            'suppressed emails, cancel' => [
+                'status' => 'cancelled',
                 'shouldsuppress' => true,
             ],
         ];
@@ -561,10 +571,11 @@ class upload_test extends \advanced_testcase {
 
     /**
      * Tests that the email suppression property is considered when signing up users.
+     * @param string $status status of session to use in csv
      * @param bool $shouldsuppress
      * @dataProvider email_suppression_provider
      */
-    public function test_email_suppression($shouldsuppress) {
+    public function test_email_suppression(string $status, bool $shouldsuppress) {
         /** @var \mod_facetoface_generator $generator */
         $generator = $this->getDataGenerator()->get_plugin_generator('mod_facetoface');
 
@@ -572,7 +583,7 @@ class upload_test extends \advanced_testcase {
         // Note the f2f must have a confirmation message & subject set, otherwise no emails will be sent ever.
         $course = $this->getDataGenerator()->create_course();
         $facetoface = $generator->create_instance(['course' => $course->id, 'confirmationmessage' => 'test',
-            'confirmationsubject' => 'test']);
+            'confirmationsubject' => 'test', 'cancellationmessage' => 'test', 'cancellationsubject' => 'test']);
         $student = $this->getDataGenerator()->create_and_enrol($course, 'student');
 
         $this->setCurrentTimeStart();
@@ -595,7 +606,7 @@ class upload_test extends \advanced_testcase {
         $record = (object) [
             'email' => $student->email,
             'session' => $session->id,
-            'status' => 'booked',
+            'status' => $status,
         ];
 
         $records = [$record];

--- a/version.php
+++ b/version.php
@@ -30,8 +30,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024070500;
-$plugin->release   = 2024070500;
+$plugin->version   = 2024070900;
+$plugin->release   = 2024070900;
 $plugin->requires  = 2023100900;  // Requires 4.3.
 $plugin->component = 'mod_facetoface';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
**Changes**
- An extension on the suppress bulk upload emails feature added in https://github.com/catalyst/moodle-mod_facetoface/pull/168
- Now also suppresses cancel emails, since they are handled separately from signup emails.

**Testing**
- Manual testing - passed
- Covered by updated unit tests