### PR TITLE
Ignore case option

### DIFF
--- a/classes/booking_manager.php
+++ b/classes/booking_manager.php
@@ -56,6 +56,9 @@ class booking_manager {
     /** @var bool When true, confirmation emails are not sent. */
     private $suppressemail = false;
 
+    /** @var bool Will ignore case when matching users */
+    private $caseinsensitive = false;
+
     /**
      * Constructor for the booking manager.
      * @param int $f The facetoface module ID.
@@ -165,7 +168,6 @@ class booking_manager {
      * @return array An array of errors.
      */
     public function validate($timenow = null): array {
-        global $DB;
         $errors = [];
         $sessioncapacitycache = [];
 
@@ -183,7 +185,7 @@ class booking_manager {
             $entry->discountcode = $entry->discountcode ?? '';
 
             // Validate and get user.
-            $userids = $DB->get_records('user', ['email' => $entry->email], 'id');
+            $userids = $this->match_users($entry->email, 'id');
 
             // Multiple matched, ambiguous which is the real one.
             if (count($userids) > 1) {
@@ -297,6 +299,18 @@ class booking_manager {
     }
 
     /**
+     * Match users for a given email, taking into account case sensitivity.
+     * @param string $email
+     * @param string $fields fields to return
+     * @return array of users, with specified fields
+     */
+    private function match_users(string $email, string $fields): array {
+        global $DB;
+        $equals = $DB->sql_equal('email', ':email', !$this->caseinsensitive);
+        return $DB->get_records_select('user', $equals, ['email' => $email], 'id', $fields);
+    }
+
+    /**
      * Transform notification type to internal representation.
      *
      * @param string $type Notification type.
@@ -321,15 +335,13 @@ class booking_manager {
      * @throws moodle_exception
      */
     public function process() {
-        global $DB;
-
         if (!empty($this->validate())) {
             throw new moodle_exception('error:cannotprocessbookingsvalidationerrorsexist', 'facetoface');
         }
 
         // Records should be valid at this point.
         foreach ($this->get_iterator() as $entry) {
-            $user = $DB->get_record('user', ['email' => $entry->email]);
+            $user = current($this->match_users($entry->email, '*'));
             $session = facetoface_get_session($entry->session);
 
             // Get signup type.
@@ -402,5 +414,13 @@ class booking_manager {
      */
     public function suppress_email() {
         $this->suppressemail = true;
+    }
+
+    /**
+     * Sets case insensitive match value
+     * @param bool $value
+     */
+    public function set_case_insensitive(bool $value) {
+        $this->caseinsensitive = $value;
     }
 }

--- a/classes/form/confirm_bookings_form.php
+++ b/classes/form/confirm_bookings_form.php
@@ -43,6 +43,7 @@ class confirm_bookings_form extends moodleform {
         $mform = $this->_form;
         $fileid = $this->_customdata['fileid'] ?? 0;
         $f = $this->_customdata['f'] ?? 0;
+        $caseinsensitive = $this->_customdata['caseinsensitive'] ?? true;
 
         // Suppress email checkbox.
         $mform->addElement('advcheckbox', 'suppressemail', get_string('suppressemail', 'facetoface'), '', [], [0, 1]);
@@ -56,6 +57,9 @@ class confirm_bookings_form extends moodleform {
         // Reference to the uploaded file.
         $mform->addElement('hidden', 'fileid', $fileid);
         $mform->setType('fileid', PARAM_INT);
+
+        $mform->addElement('hidden', 'caseinsensitive', $caseinsensitive);
+        $mform->setType('caseinsensitive', PARAM_BOOL);
 
         $backurl = new moodle_url('/mod/facetoface/upload.php', ['f' => $f]);
         $htmlbuttons = $OUTPUT->render((new single_button(

--- a/classes/form/upload_bookings_form.php
+++ b/classes/form/upload_bookings_form.php
@@ -63,6 +63,9 @@ class upload_bookings_form extends \moodleform {
         $mform->addElement('static', 'csvuploadhelp', '',
             nl2br(get_string('facetoface:uploadbookingsfiledesc', 'mod_facetoface')));
 
+        $mform->addElement('advcheckbox', 'caseinsensitive', get_string('caseinsensitive', 'mod_facetoface'));
+        $mform->setDefault('caseinsensitive', true);
+
         // The facetoface module ID.
         $mform->addElement('hidden', 'f');
         $mform->setType('f', PARAM_INT);

--- a/lang/en/facetoface.php
+++ b/lang/en/facetoface.php
@@ -833,3 +833,4 @@ $string['eventupdatesessionfailed'] = 'Session update (FAILED)';
 $string['waitliststatus'] = 'You have a place on the waitlist of the following session';
 $string['addtoallsessions'] = 'Add users to all (upcoming) sessions';
 $string['addtoallsessions_help'] = 'Use this option if you want to add users to all upcoming Face-to-Face sessions. When this uption is toggled, the selected users will be added to this session and all other future sessions in the activity.';
+$string['caseinsensitive'] = 'Case insensitive';

--- a/lib.php
+++ b/lib.php
@@ -92,9 +92,7 @@ define('MDL_F2F_STATUS_FULLY_ATTENDED',     100);
 
 /**
  * Returns the list of possible facetoface status.
- *
- * @param int $statuscode One of the MDL_F2F_STATUS* constants
- * @return string $string Human readable code
+ * @return array $string Human readable code
  */
 function facetoface_statuses() {
     // This array must match the status codes above, and the values

--- a/upload.php
+++ b/upload.php
@@ -36,6 +36,7 @@ $fileid = optional_param('fileid', 0, PARAM_INT); // The fileid of the file uplo
 $validate = optional_param('validate', 0, PARAM_INT); // Whether or not the user wants to process the upload (after verification).
 $process = optional_param('process', 0, PARAM_INT); // Whether or not the user wants to process the upload (after verification).
 $step = optional_param('step', '', PARAM_ALPHA); // The current step in the process.
+$caseinsensitive = optional_param('caseinsensitive', false, PARAM_BOOL); // If emails should match a user case insensitively.
 
 if (!$facetoface = $DB->get_record('facetoface', ['id' => $f])) {
     throw new moodle_exception('error:incorrectfacetofaceid', 'facetoface');
@@ -63,10 +64,11 @@ if ($validate) {
     $data = $mform->get_data();
     $fileid = $data->csvfile ?: 0;
 
-    $mform = new confirm_bookings_form(null, ['f' => $f, 'fileid' => $fileid]);
+    $mform = new confirm_bookings_form(null, ['f' => $f, 'fileid' => $fileid, 'caseinsensitive' => $caseinsensitive]);
 
     $bm = new booking_manager($f);
     $bm->load_from_file($fileid);
+    $bm->set_case_insensitive($caseinsensitive);
 
     // Validate entries.
     $errors = $bm->validate();
@@ -76,6 +78,7 @@ if ($validate) {
     // Form submitted, and ready for processing -> process.
     $bm = new booking_manager($f);
     $bm->load_from_file($fileid);
+    $bm->set_case_insensitive($caseinsensitive);
 
     // Get the options selected by the user at confirm time.
     $confirmdata = (new confirm_bookings_form(null))->get_data();

--- a/version.php
+++ b/version.php
@@ -30,8 +30,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023101906;
-$plugin->release   = 2023101906;
+$plugin->version   = 2023101907;
+$plugin->release   = 2023101907;
 $plugin->requires  = 2022031500;  // Requires 4.0.
 $plugin->component = 'mod_facetoface';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
**Changes**
- Adds options when uploading users in csv, to match them case insensitively.
- Default on, because Moodle also generally does not allow duplicate emails when ignoring case. So for most people, on is the most logical option.

**Testing**
- Manual testing - passed
- Also covered by unit tests

**Cherry picks**
- `MOODLE_403_STABLE`: https://github.com/catalyst/moodle-mod_facetoface/pull/181