### PR TITLE
Issue #190: Fix long links displaying correctly in invite.ics

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -3147,9 +3147,8 @@ function facetoface_ical_escape($text, $converthtml=false) {
         $text
     );
 
-    // Text should be wordwrapped at 75 octets, and there should be one whitespace after the newline that does the wrapping.
-    $text = wordwrap($text, 75, " \n ", true);
-
+    // Text should be wrapped at 75 octets, and there should be one whitespace after the newline that does the wrapping.
+    $text = rtrim(chunk_split($text, 75, "\n "), "\n ");
     return $text;
 }
 


### PR DESCRIPTION
**Description:** The issue described in #190 has been resolved by switching to a combination of `rtrim` and `chunk_split`.

---

## Problem

When we create the `.ics` file, we need to conform to the RFC ([outlined here](https://icalendar.org/iCalendar-RFC-5545/3-1-content-lines.html)).

To do this, we use the [`wordwrap` function](https://www.php.net/manual/en/function.wordwrap.php). This function wraps at word boundaries (in this case, since we set the argument `$cut_long_words` to true , it only does this for words less than the limit) and removes any trailing and/or leading whitespace. For example:

```php
//                            ⌄ 20 characters reached here
$string = 'verylongwording ashorter word here';
echo wordwrap($damn, 20, "\n", true);

//Output:
//verylongwording
//ashorter word here
```

> [!NOTE]
>  See that the `wordwrap` function doesn't wrap at exactly 20 characters, and that trailing/leading spaces at the boundary are removed.

This is problematic when we view this text in a calendar client.

This causes issues when we render this text. Even though the [RFC requires each line in the description to be no more than 75 octets/characters](https://icalendar.org/iCalendar-RFC-5545/3-1-content-lines.html), the container holding such text is not limited by this - i.e it is responsive. In Google Calendar, the container is ~500 pixels, displaying ~55 characters. 

This meant that the above output when rendered could look like so:

```php
//verylongwordingashorter word here
```

This is the same problem as described in Issue #183. That was resolved in #184 by adding a space prior to the new line. But this breaks long links/words, for example:

Prior to PR #184: https://giithub.com/catalyst/moodle-mod_facetoface/pull/191
After PR #184: https://giithub.com/cat alyst/moodle-mod_facet oface/pull/191

## Solution

Use a combination of `rtrim` and `chunk_split` instead of `wordwrap`. This is adapted from [this Stackoverflow answer](https://stackoverflow.com/a/48970066) about the same issue.

The `chunk_split` function wraps at the exact length specified and keeps whitespace.

This still follows the RFC [outlined here](https://icalendar.org/iCalendar-RFC-5545/3-1-content-lines.html).

## Testing Instructions
1. Add plugin to a Moodle 4.3 site
2. Create XS test course
3. Add activity module
4. In the form, add a title and click 'Save and display'
5. Click 'Add a new session'
6. Set 'Session date/time known' to Yes, add a start and finish time in the current week
7. Add the following to the details section
```
Moodle is a free, online Learning Management system enabling educators to create their own private website filled with dynamic courses that extend learning, any time, anywhere. Whether you're a teacher, student or administrator, Moodle can meet your needs.

https://github.com/moodle/moodle/blob/321e04d630324c44929c931acfcce344b06e4a98/tag/classes/reportbuilder/local/entities/tag.php
```
8. Save changes
9. Sign up for session (no need to change notification type)
10. Check Mailhog, find first email
![image](https://github.com/user-attachments/assets/55274917-b92d-4132-a35f-758891ad230b)
11. Go to MIME tab and download `invite.ics` file
![image](https://github.com/user-attachments/assets/6f272ea1-e2d1-4184-8ef4-9a0647d4ab80)
12. Import into email client
13. Note that email is broken
![image](https://github.com/user-attachments/assets/c724df69-800a-4c0a-b7fa-ea4011c17907)
14. Checkout working branch
```
git checkout origin/190-MOODLE_403_STABLE-ics-output 
```
15. Cancel booking
16. Repeat steps 9 - 12
17. Description should be formatted correctly
![image](https://github.com/user-attachments/assets/b2fce384-e81c-4bdf-bf28-e1728cfbfee4)

 