### PR TITLE
Issue #201: Restrict ability for student to cancel

### DIFF
--- a/cancelsignup.php
+++ b/cancelsignup.php
@@ -140,12 +140,21 @@ $signedup = facetoface_check_signup($facetoface->id);
 echo $OUTPUT->box_start();
 echo $OUTPUT->heading($heading);
 
-if ($signedup) {
-    facetoface_print_session($session, $viewattendees);
-    $mform->display();
-} else {
+if (!$signedup) {
     throw new moodle_exception('notsignedup', 'facetoface', $returnurl);
 }
+
+if ($session->datetimeknown && $cancelrestriction = get_config('facetoface', 'cancelrestriction')) {
+    // Sessions can have multiple dates. Use first date found for the session.
+    $sessionstart = $session->sessiondates[0]->timestart;
+    $timenow = time();
+    if ($timenow > ($sessionstart - $cancelrestriction)) {
+        throw new moodle_exception('error:cancellationtooclose', 'facetoface', '', format_time($cancelrestriction));
+    }
+}
+
+facetoface_print_session($session, $viewattendees);
+$mform->display();
 
 echo $OUTPUT->box_end();
 echo $OUTPUT->footer($course);

--- a/cancelsignup.php
+++ b/cancelsignup.php
@@ -144,13 +144,9 @@ if (!$signedup) {
     throw new moodle_exception('notsignedup', 'facetoface', $returnurl);
 }
 
-if ($session->datetimeknown && $cancelrestriction = get_config('facetoface', 'cancelrestriction')) {
-    // Sessions can have multiple dates. Use first date found for the session.
-    $sessionstart = $session->sessiondates[0]->timestart;
-    $timenow = time();
-    if ($timenow > ($sessionstart - $cancelrestriction)) {
-        throw new moodle_exception('error:cancellationtooclose', 'facetoface', '', format_time($cancelrestriction));
-    }
+if (!facetoface_cancellation_allowed($session)) {
+    $restriction = get_config('facetoface', 'cancelrestriction');
+    throw new moodle_exception('error:cancellationtooclose', 'facetoface', '', format_time($restriction));
 }
 
 facetoface_print_session($session, $viewattendees);

--- a/lang/en/facetoface.php
+++ b/lang/en/facetoface.php
@@ -159,6 +159,7 @@ $string['error:multipleusersmatched'] = 'Multiple users matched to identifier {$
 $string['error:addalreadysignedupattendee'] = '{$a} is already signed-up for this Face-to-Face activity.';
 $string['error:addattendee'] = 'Could not add {$a} to the session.';
 $string['error:cancellationsnotallowed'] = 'You are not allowed to cancel this sign-up.';
+$string['error:cancellationtooclose'] = 'You are not allowed to cancel this sign-up. Bookings can only be cancelled {$a} before session.';
 $string['error:cancelbooking'] = 'There was a problem cancelling your booking';
 $string['error:cannotemailmanager'] = 'Sent reminder mail for submission id {$a->submissionid} to user {$a->userid}, but could not send the message for the user\'s manager email address ({$a->manageremail}).';
 $string['error:cannotemailuser'] = 'Could not send out mail for submission id {$a->submissionid} to user {$a->userid} ({$a->useremail}).';

--- a/lang/en/facetoface.php
+++ b/lang/en/facetoface.php
@@ -400,6 +400,8 @@ $string['setting:attendeesexportfields_caption'] = 'Attendees export fields';
 $string['setting:attendeesexportfields'] = 'Select the fields to be included in a session\'s exported list of attendees. This will be in addition to the attendee\'s first and last name.';
 $string['setting:sessioncompletiondate'] = 'When enabled, the session finish date will be used as the completion time when marking attendance.';
 $string['setting:sessioncompletiondate_caption'] = 'Use session finish date and time for completion:';
+$string['setting:cancelrestriction'] = 'Set the minimum number of hours before a session that students can cancel their booking. Within this time period, students cannot cancel themselves.';
+$string['setting:cancelrestriction_caption'] = 'Cancellation Restriction';
 $string['setting:enableapprovals'] = 'When disabled, the option to add approvals via the activity setting is no longer available.';
 $string['setting:enableapprovals_caption'] = 'Enable manager approvals:';
 $string['setting:defaultcancellationinstrmngr'] = 'Default cancellation message sent to managers.';
@@ -413,6 +415,7 @@ This is to advise that [firstname] [lastname] is no longer signed-up for the fol
 $string['setting:defaultcancellationmessage'] = 'Default cancellation message sent to the user.';
 $string['setting:defaultcancellationmessage_caption'] = 'Cancellation message';
 $string['setting:defaultcancellationmessagedefault'] = 'This is to advise that your booking on the following course has been cancelled:
+
 
 ***BOOKING CANCELLED***
 

--- a/lang/en/facetoface.php
+++ b/lang/en/facetoface.php
@@ -401,8 +401,8 @@ $string['setting:attendeesexportfields_caption'] = 'Attendees export fields';
 $string['setting:attendeesexportfields'] = 'Select the fields to be included in a session\'s exported list of attendees. This will be in addition to the attendee\'s first and last name.';
 $string['setting:sessioncompletiondate'] = 'When enabled, the session finish date will be used as the completion time when marking attendance.';
 $string['setting:sessioncompletiondate_caption'] = 'Use session finish date and time for completion:';
-$string['setting:cancelrestriction'] = 'Set the minimum number of hours before a session that students can cancel their booking. Within this time period, students cannot cancel themselves.';
-$string['setting:cancelrestriction_caption'] = 'Cancellation Restriction';
+$string['setting:cancelrestriction'] = 'Minimum time before a session that students can cancel their booking. Within this period, cancellations are not allowed.';
+$string['setting:cancelrestriction_caption'] = 'Cancellation restriction';
 $string['setting:enableapprovals'] = 'When disabled, the option to add approvals via the activity setting is no longer available.';
 $string['setting:enableapprovals_caption'] = 'Enable manager approvals:';
 $string['setting:defaultcancellationinstrmngr'] = 'Default cancellation message sent to managers.';
@@ -416,7 +416,6 @@ This is to advise that [firstname] [lastname] is no longer signed-up for the fol
 $string['setting:defaultcancellationmessage'] = 'Default cancellation message sent to the user.';
 $string['setting:defaultcancellationmessage_caption'] = 'Cancellation message';
 $string['setting:defaultcancellationmessagedefault'] = 'This is to advise that your booking on the following course has been cancelled:
-
 
 ***BOOKING CANCELLED***
 

--- a/lib.php
+++ b/lib.php
@@ -4372,8 +4372,9 @@ function facetoface_cancellation_allowed(stdClass $session): bool {
         return true;
     }
 
+    $configenabled = get_config('facetoface', 'cancelrestriction_enabled');
     $cancelrestriction = get_config('facetoface', 'cancelrestriction');
-    if (!$cancelrestriction) {
+    if (!$configenabled || !$cancelrestriction) {
         return true;
     }
 

--- a/lib.php
+++ b/lib.php
@@ -4361,6 +4361,28 @@ function facetoface_get_all_user_name_fields($returnsql = false, $tableprefix = 
     return $ret;
 }
 
+/**
+ * Check if cancellation is allowed based on time restriction.
+ *
+ * @param stdClass $session The session object
+ * @return bool true if cancellation is allowed, false otherwise
+ */
+function facetoface_cancellation_allowed(stdClass $session): bool {
+    if (!$session->datetimeknown) {
+        return true;
+    }
+
+    $cancelrestriction = get_config('facetoface', 'cancelrestriction');
+    if (!$cancelrestriction) {
+        return true;
+    }
+
+    // Sessions can have multiple dates. Use first date found for the session.
+    $sessionstart = $session->sessiondates[0]->timestart;
+    $timenow = time();
+    return $timenow <= ($sessionstart - $cancelrestriction);
+}
+
 /*
  * facetoface assignment candidates
  */

--- a/renderer.php
+++ b/renderer.php
@@ -186,11 +186,20 @@ class mod_facetoface_renderer extends plugin_renderer_base {
                         get_string('moreinfo', 'facetoface'),
                         ['title' => get_string('moreinfo', 'facetoface')]) . html_writer::empty_tag('br');
                 if ($session->allowcancellations) {
-                    $options .= html_writer::link(
-                        'cancelsignup.php?s=' . $session->id . '&backtoallsessions=' . $session->facetoface,
-                        get_string('cancelbooking', 'facetoface'),
-                        ['title' => get_string('cancelbooking', 'facetoface')]
-                    );
+                    if (facetoface_cancellation_allowed($session)) {
+                        $options .= html_writer::link(
+                            'cancelsignup.php?s=' . $session->id . '&backtoallsessions=' . $session->facetoface,
+                            get_string('cancelbooking', 'facetoface'),
+                            ['title' => get_string('cancelbooking', 'facetoface')]
+                        );
+                    } else {
+                        $cancelrestriction = get_config('facetoface', 'cancelrestriction');
+                        $options .= html_writer::link(
+                            '',
+                            get_string('cancelbooking', 'facetoface'),
+                            ['title' => get_string('error:cancellationtooclose', 'facetoface', format_time($cancelrestriction)), 'class' => 'disabled']
+                        );
+                    }
                 }
             } else if (!$sessionstarted && !$bookedsession && $signuplinks) {
                 $options .= html_writer::link('signup.php?s='.$session->id.'&backtoallsessions='.$session->facetoface,

--- a/settings.php
+++ b/settings.php
@@ -92,6 +92,15 @@ $settings->add(new admin_setting_configcheckbox(
     0
 ));
 
+$setting = new admin_setting_configduration(
+    'facetoface/cancelrestriction',
+    get_string('setting:cancelrestriction_caption', 'facetoface'),
+    get_string('setting:cancelrestriction', 'facetoface'),
+    172800
+);
+$setting->set_enabled_flag_options(admin_setting_flag::ENABLED, false);
+$settings->add($setting);
+
 $settings->add(new admin_setting_heading(
     'facetoface/manageremail_header',
     get_string('manageremailheading', 'facetoface'),

--- a/signup.php
+++ b/signup.php
@@ -265,11 +265,20 @@ if (!$isbulksignup && $signedup) {
     if (!($session->datetimeknown && facetoface_has_session_started($session, $timenow)) && $session->allowcancellations) {
         // Cancellation link.
         $cancellationurl = new moodle_url('cancelsignup.php', ['s' => $session->id, 'backtoallsessions' => $backtoallsessions]);
-        echo html_writer::link(
-            $cancellationurl,
-            get_string('cancelbooking', 'facetoface'),
-            ['title' => get_string('cancelbooking', 'facetoface')]
-        );
+        if (facetoface_cancellation_allowed($session)) {
+            echo html_writer::link(
+                $cancellationurl,
+                get_string('cancelbooking', 'facetoface'),
+                ['title' => get_string('cancelbooking', 'facetoface')]
+            );
+        } else {
+            $cancelrestriction = get_config('facetoface', 'cancelrestriction');
+            echo html_writer::link(
+                '',
+                get_string('cancelbooking', 'facetoface'),
+                ['title' => get_string('error:cancellationtooclose', 'facetoface', format_time($cancelrestriction)), 'class' => 'disabled']
+            );
+        }
         echo ' &ndash; ';
     }
 

--- a/tests/session_test.php
+++ b/tests/session_test.php
@@ -377,4 +377,94 @@ It has plain text stuff in it<br />";
         $completiondata = $completion->get_data($cm, false, $student->id);
         $this->assertEquals($sessiondate + HOURSECS, $completiondata->timemodified);
     }
+
+    /**
+     * Data provider for test_cancellation_allowed
+     *
+     * @return array
+     */
+    public static function cancellation_allowed_provider(): array {
+        return [
+            'setting disabled' => [
+                'configenabled' => false,
+                'restriction' => DAYSECS,
+                'sessiondates' => [
+                    ['timestart' => DAYSECS, 'timefinish' => DAYSECS * 2],
+                ],
+                'expected' => true,
+            ],
+            'no restriction value set' => [
+                'configenabled' => true,
+                'restriction' => 0,
+                'sessiondates' => [
+                    ['timestart' => DAYSECS, 'timefinish' => DAYSECS * 2],
+                ],
+                'expected' => true,
+            ],
+            'within allowed time' => [
+                'configenabled' => true,
+                'restriction' => DAYSECS,
+                'sessiondates' => [
+                    ['timestart' => DAYSECS * 3, 'timefinish' => DAYSECS * 4],
+                ],
+                'expected' => true,
+            ],
+            'too close to session' => [
+                'configenabled' => true,
+                'restriction' => DAYSECS * 2,
+                'sessiondates' => [
+                    ['timestart' => DAYSECS, 'timefinish' => DAYSECS * 2],
+                ],
+                'expected' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Test the cancellation allowed check.
+     *
+     * @dataProvider cancellation_allowed_provider
+     */
+    public function test_cancellation_allowed(
+        bool $configenabled,
+        int $restriction,
+        array $sessiondates,
+        bool $expected
+    ): void {
+        global $CFG;
+        require_once($CFG->dirroot . '/mod/facetoface/lib.php');
+
+        // Configure settings.
+        // Because of the admin setting we are using, there is an addition "_enabled" config we need to set.
+        set_config('cancelrestriction_enabled', $configenabled, 'facetoface');
+        set_config('cancelrestriction', $restriction, 'facetoface');
+
+        // Setup course.
+        $generator = $this->getDataGenerator()->get_plugin_generator('mod_facetoface');
+        $course = $this->getDataGenerator()->create_course();
+        $facetoface = $generator->create_instance(['course' => $course->id]);
+
+        // Create session.
+        $now = time();
+        $sessiondata = [
+            'facetoface' => $facetoface->id,
+            'capacity' => 3,
+            'allowoverbook' => 0,
+            'duration' => 1.5,
+            'normalcost' => 111,
+            'discountcost' => 11,
+            // We need to set session date unique to each provider as a unix timestamp.
+            'sessiondates' => array_map(function($date) use ($now) {
+                return [
+                    'timestart' => $now + $date['timestart'],
+                    'timefinish' => $now + $date['timefinish'],
+                ];
+            }, $sessiondates)
+        ];
+        $session = $generator->create_session($sessiondata);
+
+        // Check if provided user can cancel.
+        $result = facetoface_cancellation_allowed($session);
+        $this->assertEquals($expected, $result);
+    }
 }


### PR DESCRIPTION
**Description:** Add time restriction so that students can only cancel prior to some customisable period.

**Changes made:**

1. Add new admin setting `cancelrestriction`, `configduration` type with 'Enabled' flag option
2. Default value is two days
3. Disabled by default

**Testing Instructions:**

1. Create F2F module, create session in the future (i.e. 1 week)
2. Sign up to session
3. Check that you can still cancel
4. Visit plugin setting, enable time restriction (i.e. 2 weeks)
5. Check that you can no longer cancel the session