### PR TITLE
Issue #205: Activity front screen styling changes

### DIFF
--- a/customfield.php
+++ b/customfield.php
@@ -45,7 +45,7 @@ if ($id > 0) {
 // If custom field is selected to be shown on custom page, alert user field cannot be deleted until
 // this is changed.
 // $id = 0 occurs when creating a new customfield.
-if ($id != 0 && $id == get_config('facetoface', 'displaycustomfield')) {
+if ($d && $id != 0 && $id == get_config('facetoface', 'displaycustomfield')) {
     throw new moodle_exception('error:fieldselected', 'facetoface', '');
 }
 

--- a/lib.php
+++ b/lib.php
@@ -3063,6 +3063,10 @@ function facetoface_get_visiblefield_data($session) {
         'sessionid' => $session->id
     ]);
 
+    if ($fieldname == null || $fieldvalue == null) {
+        return null;
+    }
+
     return (object)[
         'name' => $fieldname,
         'value' => $fieldvalue,

--- a/lib.php
+++ b/lib.php
@@ -3038,6 +3038,13 @@ function facetoface_cm_info_view(cm_info $coursemodule) {
     $coursemodule->set_content($output);
 }
 
+
+/**
+ * Gets the visible custom field title and value for a face-to-face session
+ *
+ * @param object $session A session object containing session details
+ * @return object|null Object containing the field 'name' and 'value', or null setting disabled
+ */
 function facetoface_get_visiblefield_data($session) {
     global $DB;
     $visiblefieldcolumn = get_config('facetoface', 'displaycustomfield');

--- a/lib.php
+++ b/lib.php
@@ -2834,13 +2834,22 @@ function facetoface_cm_info_view(cm_info $coursemodule) {
                     ]);
                 }
 
-                $output .= html_writer::start_tag('div', ['class' => 'f2fsessiongroup'])
-                    . html_writer::tag('span', $status, ['class' => 'f2fsessionnotice'])
-                    . html_writer::start_tag('div', ['class' => 'f2fsession f2fsignedup'])
-                    . html_writer::tag('div', $sessiondates, ['class' => 'f2fsessiontime'])
-                    . html_writer::tag('div', $span . $moreinfolink . $attendeeslink . $cancellink, ['class' => 'f2foptions'])
-                    . html_writer::end_tag('div')
-                    . html_writer::end_tag('div');
+                $output .= html_writer::start_tag('div', ['class' => 'f2fsessiongroup']);
+                $output .= html_writer::tag('span', $status, ['class' => 'f2fsessionnotice']);
+                $output .= html_writer::start_tag('div', ['class' => 'f2fsession f2fsignedup']);
+                $output .= html_writer::tag('div', $sessiondates, ['class' => 'f2fsessiontime']);
+                $output .= html_writer::start_tag('div', ['class' => 'f2foptions']);
+                if ($visiblefieldcolumn = facetoface_get_visiblefield_data($session)) {
+                    $output .= html_writer::start_tag('div', ['class' => 'f2fcustomfieldcolumn']);
+                    $fieldnamehtml = html_writer::tag('span', $visiblefieldcolumn->name.':', ['class' => 'f2fsessionnotice']);
+                    $fieldvaluehtml = html_writer::tag('span', $visiblefieldcolumn->value);
+                    $output .= html_writer::tag('div', $fieldnamehtml . $fieldvaluehtml);
+                    $output .= html_writer::end_tag('div');
+                }
+                $output .= html_writer::tag('div', $span . $moreinfolink . $attendeeslink . $cancellink);
+                $output .= html_writer::end_tag('div');
+                $output .= html_writer::end_tag('div');
+                $output .= html_writer::end_tag('div');
             }
         }
         // Add "view all sessions" row to table.

--- a/lib.php
+++ b/lib.php
@@ -2924,21 +2924,8 @@ function facetoface_cm_info_view(cm_info $coursemodule) {
                 }
 
                 // Check if custom fields exist, and add to sessionobject if setting is enabled.
-                $visiblefieldcolumn = get_config('facetoface', 'displaycustomfield');
-                if ($visiblefieldcolumn) {
-                    // Get field title.
-                    $fieldname = $DB->get_field('facetoface_session_field', 'name', [
-                        'id' => $visiblefieldcolumn,
-                    ]);
-                    // Get field value for the session.
-                    $fieldvalue = $DB->get_field('facetoface_session_data', 'data', [
-                        'fieldid' => $visiblefieldcolumn,
-                        'sessionid' => $session->id
-                    ]);
-                    $sessionobject->customfield = (object)[
-                        'name' => $fieldname,
-                        'value' => $fieldvalue,
-                    ];
+                if ($visiblefieldcolumn = facetoface_get_visiblefield_data($session)) {
+                    $sessionobject->customfield = $visiblefieldcolumn;
                 }
 
                 $j++;
@@ -3040,6 +3027,30 @@ function facetoface_cm_info_view(cm_info $coursemodule) {
     }
 
     $coursemodule->set_content($output);
+}
+
+function facetoface_get_visiblefield_data($session) {
+    global $DB;
+    $visiblefieldcolumn = get_config('facetoface', 'displaycustomfield');
+
+    if (!$visiblefieldcolumn) {
+        return null;
+    }
+
+    // Get field title.
+    $fieldname = $DB->get_field('facetoface_session_field', 'name', [
+        'id' => $visiblefieldcolumn,
+    ]);
+    // Get field value for the session.
+    $fieldvalue = $DB->get_field('facetoface_session_data', 'data', [
+        'fieldid' => $visiblefieldcolumn,
+        'sessionid' => $session->id
+    ]);
+
+    return (object)[
+        'name' => $fieldname,
+        'value' => $fieldvalue,
+    ];
 }
 
 /**

--- a/lib.php
+++ b/lib.php
@@ -2960,7 +2960,7 @@ function facetoface_cm_info_view(cm_info $coursemodule) {
                         $output .= html_writer::start_tag('div', ['class' => 'f2foptions']);
                         $output .= html_writer::start_tag('div', ['class' => 'f2fcustomfieldcolumn']);
                         $fieldnamehtml = html_writer::tag('span', $session->customfield->name.':', ['class' => 'f2fsessionnotice']);
-                        $fieldvaluehtml = html_writer::tag('span', $session->customfield->value, ['class' => 'f2fsessionlinks']);
+                        $fieldvaluehtml = html_writer::tag('span', $session->customfield->value);
                         $output .= html_writer::tag('div', $fieldnamehtml . $fieldvaluehtml);
                         $output .= html_writer::end_tag('div');
                         $output .= html_writer::end_tag('div');
@@ -3002,7 +3002,7 @@ function facetoface_cm_info_view(cm_info $coursemodule) {
                     if ($visiblefieldcolumn) {
                         $output .= html_writer::start_tag('div', ['class' => 'f2fcustomfieldcolumn']);
                         $fieldnamehtml = html_writer::tag('span', $session->customfield->name.':', ['class' => 'f2fsessionnotice']);
-                        $fieldvaluehtml = html_writer::tag('span', $session->customfield->value, ['class' => 'f2fsessionlinks']);
+                        $fieldvaluehtml = html_writer::tag('span', $session->customfield->value);
                         $output .= html_writer::tag('div', $fieldnamehtml . $fieldvaluehtml);
                         $output .= html_writer::end_tag('div');
                     }

--- a/styles.css
+++ b/styles.css
@@ -34,9 +34,15 @@
     display: flex;
     min-width: 60px;
     max-width: 50%;
-    justify-content: space-between;
+    justify-content: end;
     width: 100%;
 }
+
+.f2foptions:has(> :last-child:nth-child(2)) {
+    justify-content: space-between;
+}
+
+
 .f2fsessionlinks,
 .f2fsessionnotice {
     font-size: 11px;

--- a/styles.css
+++ b/styles.css
@@ -20,14 +20,14 @@
 }
 
 .f2fcustomfieldcolumn {
-    max-width: 80%;
     width: 100%;
     display: flex;
     justify-content: center;
 }
 
 .f2fcustomfieldcolumn > div {
-    max-width: 100%;
+    width: 100%;
+    padding-left: 2rem;
 }
 
 .f2foptions {

--- a/styles.css
+++ b/styles.css
@@ -21,13 +21,21 @@
 
 .f2fcustomfieldcolumn {
     max-width: 80%;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+}
+
+.f2fcustomfieldcolumn > div {
+    max-width: 100%;
 }
 
 .f2foptions {
     display: flex;
     min-width: 60px;
     max-width: 50%;
-    justify-content: flex-end;
+    justify-content: space-between;
+    width: 100%;
 }
 .f2fsessionlinks,
 .f2fsessionnotice {

--- a/tests/session_test.php
+++ b/tests/session_test.php
@@ -624,4 +624,69 @@ It has plain text stuff in it<br />";
             $this->assertStringNotContainsString('Test value', $output);
         }
     }
+
+    /**
+     * Test retrieving visible custom session field data for cm view on course page.
+     */
+    public function test_get_visiblefield_data(): void {
+        global $DB;
+
+        $this->resetAfterTest();
+
+        /** @var \mod_facetoface_generator $generator */
+        $generator = $this->getDataGenerator()->get_plugin_generator('mod_facetoface');
+
+        // Setup course and participants.
+        $course = $this->getDataGenerator()->create_course();
+        $facetoface = $generator->create_instance(['course' => $course->id]);
+
+        // Create a custom field.
+        $fieldid = $DB->insert_record('facetoface_session_field', [
+            'name' => 'Location',
+            'shortname' => 'location',
+            'type' => 0,
+            'required' => 0,
+            'isfilter' => 0,
+            'showinsummary' => 1,
+            'visibleto' => MDL_F2F_FIELD_VISIBLETOALL, // Everyone
+        ]);
+
+        // Create a session.
+        $session = $generator->create_session([
+            'facetoface' => $facetoface->id,
+            'capacity' => 10,
+        ]);
+
+        // Add custom field data to the session.
+        $DB->insert_record('facetoface_session_data', [
+            'sessionid' => $session->id,
+            'fieldid' => $fieldid,
+            'data' => 'Test Location',
+        ]);
+
+        // Ensure returns null when no visible field is configured.
+        set_config('displaycustomfield', 0, 'facetoface');
+        $result = facetoface_get_visiblefield_data($session);
+        $this->assertNull($result);
+
+        // Ensure returns valid values when visible field is configured.
+        set_config('displaycustomfield', $fieldid, 'facetoface');
+        $result = facetoface_get_visiblefield_data($session);
+        $this->assertIsObject($result);
+        $this->assertEquals('Location', $result->name);
+        $this->assertEquals('Test Location', $result->value);
+
+        // Ensure returns null when field doesn't exist for session.
+        $newsession = $generator->create_session([
+            'facetoface' => $facetoface->id,
+            'capacity' => 10,
+        ]);
+        $result = facetoface_get_visiblefield_data($newsession);
+        $this->assertNull($result);
+
+        // Ensure returns null if custom field ID doesn't exist.
+        set_config('displaycustomfield', 999, 'facetoface');
+        $result = facetoface_get_visiblefield_data($session);
+        $this->assertNull($result);
+    }
 }


### PR DESCRIPTION
**Description:** Two changes:

1. Add fix so that if a field is selected to be shown on the course page for the module, it can be edited in the plugin settings
2. Apply CSS changes to custom field on course page view


CSS changes
<img width="792" height="135" alt="image" src="https://github.com/user-attachments/assets/26c300ba-d0d5-4882-9462-1f7f51ba1e6c" />
<img width="834" height="268" alt="image" src="https://github.com/user-attachments/assets/aa2164a8-ef77-4182-a77c-e87000eeb0cf" />

Without field
<img width="834" height="268" alt="image" src="https://github.com/user-attachments/assets/15e93f97-2549-4161-b9a6-78ed116b1f02" />
<img width="776" height="198" alt="image" src="https://github.com/user-attachments/assets/86904519-6e72-402c-bec4-755574e125aa" />


