### PR TITLE
Issue #225: Enable adding blocks on attendee pages

### DIFF
--- a/attendees.php
+++ b/attendees.php
@@ -75,7 +75,7 @@ $cancellations = facetoface_get_cancellations($session->id);
  */
 $context = context_course::instance($course->id);
 $contextmodule = context_module::instance($cm->id);
-require_course_login($course);
+require_course_login($course, true, $cm);
 
 // Actions the user can perform.
 $canviewattendees = has_capability('mod/facetoface:viewattendees', $context);
@@ -183,9 +183,6 @@ $event->trigger();
 $pagetitle = format_string($facetoface->name);
 
 $PAGE->set_url('/mod/facetoface/attendees.php', ['s' => $s]);
-$PAGE->set_context($context);
-$PAGE->set_cm($cm);
-
 $PAGE->set_title($pagetitle);
 $PAGE->set_heading($course->fullname);
 

--- a/editattendees.php
+++ b/editattendees.php
@@ -57,7 +57,7 @@ if (!$cm = get_coursemodule_from_instance('facetoface', $facetoface->id, $course
 }
 
 // Check essential permissions.
-require_course_login($course);
+require_course_login($course, true, $cm);
 $context = context_course::instance($course->id);
 require_capability('mod/facetoface:viewattendees', $context);
 


### PR DESCRIPTION
**Description:** Resolves Issue #225. We remove the calls to `set_context` and `set_cm` because these are called from `require_course_login`, see following stack trace:

```
 moodle_page->set_cm pagelib.php:1254
 require_login moodlelib.php:2411
 require_course_login moodlelib.php:2766
 {main} attendees.php:78
```

```php
// require_course_login
    } else if (isloggedin() && !isguestuser()) {
        // User is already logged in. Make sure the login is complete (user is fully setup, policies agreed).
        require_login($courseorid, $autologinguest, $cm, $setwantsurltome, $preventredirect);

// require_login
        if ($cm) {
            $PAGE->set_cm($cm, $course);

// set_cm
        // Unfortunately the context setting is a mess.
        // Let's try to work around some common block problems and show some debug messages.
        if (empty($this->_context) or $this->_context->contextlevel != CONTEXT_BLOCK) {
            $context = context_module::instance($cm->id);
            $this->set_context($context);
        }
```

If we do not remove, we get the following error:

```
Whoops\Exception\ErrorException thrown with message "Coding problem: unsupported modification of PAGE->context from 70 to 50"

Stacktrace:
#1 debugging in /var/www/facetoface/lib/pagelib.php:1210
#0 moodle_page:set_context in /var/www/facetoface/mod/facetoface/attendees.php:186
```

Note that the `view.php` already has calls to `require_course_login` with this additional arguments:

https://github.com/catalyst/moodle-mod_facetoface/blob/MOODLE_403_STABLE/view.php#L78
