### PR TITLE
Issue #227: Enable managers and admins to be enrolled into course

### DIFF
--- a/editattendees.php
+++ b/editattendees.php
@@ -91,20 +91,17 @@ if (optional_param('add', false, PARAM_BOOL) && confirm_sesskey()) {
                 continue; // Invalid userid.
             }
 
+            $user = $DB->get_record('user', ['id' => $adduser]);
             // Make sure that the user is enroled in the course.
-            if (!has_capability('moodle/course:view', $context, $adduser)) {
-                $user = $DB->get_record('user', ['id' => $adduser]);
-                // Make sure that the user is enroled in the course.
-                if (!is_enrolled($context, $user)) {
-                    $defaultroleid = null;
-                    // Get default role ID for manual enrollment.
-                    $conditions = ['courseid' => $course->id, 'enrol' => 'manual'];
-                    $defaultroleid = $DB->get_field('enrol', 'roleid', $conditions, IGNORE_MISSING);
-                    if (!enrol_try_internal_enrol($course->id, $user->id, $defaultroleid)) {
-                        $errors[] = get_string('error:enrolmentfailed', 'facetoface', fullname($user));
-                        $errors[] = get_string('error:addattendee', 'facetoface', fullname($user));
-                        continue; // Don't sign the user up.
-                    }
+            if (!is_enrolled($context, $user)) {
+                $defaultroleid = null;
+                // Get default role ID for manual enrollment.
+                $conditions = ['courseid' => $course->id, 'enrol' => 'manual'];
+                $defaultroleid = $DB->get_field('enrol', 'roleid', $conditions, IGNORE_MISSING);
+                if (!enrol_try_internal_enrol($course->id, $user->id, $defaultroleid)) {
+                    $errors[] = get_string('error:enrolmentfailed', 'facetoface', fullname($user));
+                    $errors[] = get_string('error:addattendee', 'facetoface', fullname($user));
+                    continue; // Don't sign the user up.
                 }
             }
 


### PR DESCRIPTION
**Description:** Resolves Issue #227. Removes the redundant call to `has_capability`, and instead only uses the `is_enrolled` to check