### PR TITLE
Issue #198: Update course_completion_crit_compl table on module completion

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2693,6 +2693,15 @@ function facetoface_take_individual_attendance($submissionid, $grading) {
                 $data->timemodified = $record->timefinish;
                 $completion->internal_set_data($cm, $data);
                 $completion->update_state($cm, COMPLETION_UNKNOWN, $record->userid, false);
+
+                // Update the course completion criteria entry.
+                $criteras = $completion->get_criteria(4); // 4 = completion_criteria_activity
+                foreach ($criteras as $criteria) {
+                    if ($criteria->module == 'facetoface' && $criteria->moduleinstance == $cm->id) {
+                        $criteriacompletion = $completion->get_user_completion($record->userid, $criteria);
+                        $criteriacompletion->mark_complete($record->timefinish);
+                    }
+                }
             }
         }
     }

--- a/tests/session_test.php
+++ b/tests/session_test.php
@@ -21,6 +21,8 @@ use core_date;
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
 require_once("$CFG->dirroot/mod/facetoface/lib.php");
+require_once($CFG->dirroot . '/completion/criteria/completion_criteria.php');
+require_once($CFG->dirroot . '/completion/criteria/completion_criteria_activity.php');
 
 /**
  * Test the session helper class.
@@ -369,6 +371,17 @@ It has plain text stuff in it<br />";
         facetoface_user_signup($session, $facetoface, $course, '', MDL_F2F_TEXT, MDL_F2F_STATUS_BOOKED, $student->id);
         $signup = $DB->get_record('facetoface_signups', ['sessionid' => $session->id, 'userid' => $student->id]);
 
+        // Create activity course completion criteria.
+        $cm = get_coursemodule_from_instance('facetoface', $facetoface->id, $course->id);
+        $criteriadata = (object)[
+            'id' => $course->id,
+            'criteria_activity' => [
+                $cm->id => 1
+            ]
+        ];
+        $criterion = new \completion_criteria_activity();
+        $criterion->update_config($criteriadata);
+
         // Mark attendance.
         facetoface_take_individual_attendance($signup->id, MDL_F2F_STATUS_FULLY_ATTENDED);
 
@@ -377,6 +390,10 @@ It has plain text stuff in it<br />";
         $completion = new \completion_info($course);
         $completiondata = $completion->get_data($cm, false, $student->id);
         $this->assertEquals($sessiondate + HOURSECS, $completiondata->timemodified);
+
+        // Check activity course completion criteria date matches session date.
+        $criteria = $DB->get_record('course_completion_crit_compl', ['userid' => $student->id, 'course' => $course->id]);
+        $this->assertEquals($sessiondate + HOURSECS, $criteria->timecompleted);
     }
 
     /**


### PR DESCRIPTION
**Description:** There are two reports that show module completion:

1. Activity completion - `mdl_course_module_completion`
2. Course completion - `mdl_course_completion_crit_compl`

With the current code, we are only updating the `mdl_course_module_completion` entry. This PR adds support to also update the `mdl_course_completion_crit_compl` table