### PR TITLE
Issue #227: Fix enrolling during user signup

### DIFF
--- a/editattendees.php
+++ b/editattendees.php
@@ -93,16 +93,10 @@ if (optional_param('add', false, PARAM_BOOL) && confirm_sesskey()) {
 
             $user = $DB->get_record('user', ['id' => $adduser]);
             // Make sure that the user is enroled in the course.
-            if (!is_enrolled($context, $user)) {
-                $defaultroleid = null;
-                // Get default role ID for manual enrollment.
-                $conditions = ['courseid' => $course->id, 'enrol' => 'manual'];
-                $defaultroleid = $DB->get_field('enrol', 'roleid', $conditions, IGNORE_MISSING);
-                if (!enrol_try_internal_enrol($course->id, $user->id, $defaultroleid)) {
-                    $errors[] = get_string('error:enrolmentfailed', 'facetoface', fullname($user));
-                    $errors[] = get_string('error:addattendee', 'facetoface', fullname($user));
-                    continue; // Don't sign the user up.
-                }
+            if (!facetoface_enrol_user($context, $course->id, $user->id)) {
+                $errors[] = get_string('error:enrolmentfailed', 'facetoface', fullname($user));
+                $errors[] = get_string('error:addattendee', 'facetoface', fullname($user));
+                continue; // Don't sign the user up.
             }
 
             $usernamefields = facetoface_get_all_user_name_fields(true);

--- a/lib.php
+++ b/lib.php
@@ -4420,6 +4420,22 @@ function facetoface_can_view_field(int $visibility, bool $editsessions): bool {
     }
 }
 
+function facetoface_enrol_user($context, $courseid, $userid) {
+    global $DB;
+
+    if (!is_enrolled($context, $userid)) {
+        $defaultroleid = null;
+        // Get default role ID for manual enrollment.
+        $conditions = ['courseid' => $courseid, 'enrol' => 'manual'];
+        $defaultroleid = $DB->get_field('enrol', 'roleid', $conditions, IGNORE_MISSING);
+        if (!enrol_try_internal_enrol($courseid, $userid, $defaultroleid)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 /*
  * facetoface assignment candidates
  */

--- a/lib.php
+++ b/lib.php
@@ -4420,7 +4420,15 @@ function facetoface_can_view_field(int $visibility, bool $editsessions): bool {
     }
 }
 
-function facetoface_enrol_user($context, $courseid, $userid) {
+/**
+ * Enrol a user into a course on signup.
+ *
+ * @param object $context context object (record from context table)
+ * @param integer $courseid id of the course
+ * @param integer $userid id of the user
+ * @return bool true if the given user is enrolled, false otherwise
+ */
+function facetoface_enrol_user($context, $courseid, $userid): bool {
     global $DB;
 
     if (!is_enrolled($context, $userid)) {

--- a/signup.php
+++ b/signup.php
@@ -142,15 +142,8 @@ if ($fromform = $mform->get_data()) { // Form submitted.
                 throw new moodle_exception('error:manageremailaddressmissing', 'facetoface', $returnurl);
             }
 
-            // Enrol user into course.
-            if (!is_enrolled($context, $USER->id)) {
-                $defaultroleid = null;
-                // Get default role ID for manual enrollment.
-                $conditions = ['courseid' => $course->id, 'enrol' => 'manual'];
-                $defaultroleid = $DB->get_field('enrol', 'roleid', $conditions, IGNORE_MISSING);
-                if (!enrol_try_internal_enrol($course->id, $USER->id, $defaultroleid)) {
-                    throw new moodle_exception('You cannot be enrolled to this course.');
-                }
+            if (!facetoface_enrol_user($context, $course->id, $USER->id)) {
+                throw new moodle_exception('You cannot be enrolled to this course.');
             }
 
             if ($submissionid = facetoface_user_signup(
@@ -186,17 +179,8 @@ if ($fromform = $mform->get_data()) { // Form submitted.
         throw new moodle_exception('alreadysignedup', 'facetoface', $returnurl);
     } else if (facetoface_manager_needed($facetoface) && !facetoface_get_manageremail($USER->id)) {
         throw new moodle_exception('error:manageremailaddressmissing', 'facetoface', $returnurl);
-    }
-
-    // Enrol user into course.
-    if (!is_enrolled($context, $USER->id)) {
-        $defaultroleid = null;
-        // Get default role ID for manual enrollment.
-        $conditions = ['courseid' => $course->id, 'enrol' => 'manual'];
-        $defaultroleid = $DB->get_field('enrol', 'roleid', $conditions, IGNORE_MISSING);
-        if (!enrol_try_internal_enrol($course->id, $USER->id, $defaultroleid)) {
-            throw new moodle_exception('You cannot be enrolled to this course.');
-        }
+    } else if (!facetoface_enrol_user($context, $course->id, $USER->id)) {
+        throw new moodle_exception('You cannot be enrolled to this course.');
     }
 
     if ($submissionid = facetoface_user_signup(

--- a/signup.php
+++ b/signup.php
@@ -142,6 +142,17 @@ if ($fromform = $mform->get_data()) { // Form submitted.
                 throw new moodle_exception('error:manageremailaddressmissing', 'facetoface', $returnurl);
             }
 
+            // Enrol user into course.
+            if (!is_enrolled($context, $USER->id)) {
+                $defaultroleid = null;
+                // Get default role ID for manual enrollment.
+                $conditions = ['courseid' => $course->id, 'enrol' => 'manual'];
+                $defaultroleid = $DB->get_field('enrol', 'roleid', $conditions, IGNORE_MISSING);
+                if (!enrol_try_internal_enrol($course->id, $USER->id, $defaultroleid)) {
+                    throw new moodle_exception('You cannot be enrolled to this course.');
+                }
+            }
+
             if ($submissionid = facetoface_user_signup(
                 $session,
                 $facetoface,
@@ -175,7 +186,20 @@ if ($fromform = $mform->get_data()) { // Form submitted.
         throw new moodle_exception('alreadysignedup', 'facetoface', $returnurl);
     } else if (facetoface_manager_needed($facetoface) && !facetoface_get_manageremail($USER->id)) {
         throw new moodle_exception('error:manageremailaddressmissing', 'facetoface', $returnurl);
-    } else if ($submissionid = facetoface_user_signup(
+    }
+
+    // Enrol user into course.
+    if (!is_enrolled($context, $USER->id)) {
+        $defaultroleid = null;
+        // Get default role ID for manual enrollment.
+        $conditions = ['courseid' => $course->id, 'enrol' => 'manual'];
+        $defaultroleid = $DB->get_field('enrol', 'roleid', $conditions, IGNORE_MISSING);
+        if (!enrol_try_internal_enrol($course->id, $USER->id, $defaultroleid)) {
+            throw new moodle_exception('You cannot be enrolled to this course.');
+        }
+    }
+
+    if ($submissionid = facetoface_user_signup(
         $session,
         $facetoface,
         $course,

--- a/tests/attendee_test.php
+++ b/tests/attendee_test.php
@@ -81,4 +81,46 @@ class attendee_test extends \advanced_testcase {
         $this->assertEquals('Bob', next($attendees)->firstname);
         $this->assertEquals('Charlie', next($attendees)->firstname);
     }
+
+    /**
+     * Test facetoface_enrol_user function
+     */
+    public function test_facetoface_enrol_user(): void {
+        global $DB;
+
+        $this->resetAfterTest();
+
+        // Setup course.
+        $course = $this->getDataGenerator()->create_course();
+        $context = \context_course::instance($course->id);
+
+        // Test student that is already enrolled.
+        $student1 = $this->getDataGenerator()->create_and_enrol($course, 'student');
+        $result = facetoface_enrol_user($context, $course->id, $student1->id);
+        $this->assertTrue($result);
+        $this->assertTrue(is_enrolled($context, $student1->id));
+
+        // Test student that isn't enrolled.
+        $student2 = $this->getDataGenerator()->create_user();
+        $result = facetoface_enrol_user($context, $course->id, $student2->id);
+        $this->assertTrue($result);
+        $this->assertTrue(is_enrolled($context, $student2->id));
+
+        // Test admin user with moodle/course:view capability.
+        $admin = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->role_assign('manager', $admin->id);
+        $result = facetoface_enrol_user($context, $course->id, $admin->id);
+        $this->assertTrue($result);
+        $this->assertTrue(is_enrolled($context, $admin->id));
+
+        // Test student that isn't enrolled and enrol_try_internal_enrol fails
+        // when manual enrol is disabled.
+        $manualinstance = $DB->get_record('enrol', ['courseid' => $course->id, 'enrol' => 'manual']);
+        $DB->set_field('enrol', 'status', ENROL_INSTANCE_DISABLED, ['id' => $manualinstance->id]);
+
+        $student3 = $this->getDataGenerator()->create_user();
+        $result = facetoface_enrol_user($context, $course->id, $student3->id);
+        $this->assertFalse($result);
+        $this->assertFalse(is_enrolled($context, $student3->id));
+    }
 }


### PR DESCRIPTION
**Description:** We've previously addressed manually adding attendees to a session (https://github.com/catalyst/moodle-mod_facetoface/pull/228), but this is still occurring when users themselves (those with the system moodle/course:view capability) signup for a session in a course they are not yet enrolled in.

This is because the user signup does not enrol users, whereas manually adding attendees does.

This PR aligns their behaviour