### PR TITLE
Issue #206: Add session visibility support

### DIFF
--- a/classes/external/create_session.php
+++ b/classes/external/create_session.php
@@ -110,6 +110,7 @@ class create_session extends external_api {
         $session->facetoface = $facetofaceid;
         $session->timecreated = time();
         $session->timemodified = $session->timecreated;
+        $session->visible = 1;
 
         $fields = ['capacity', 'allowoverbook', 'details', 'datetimeknown', 'duration', 'normalcost',
                    'discountcost', 'allowcancellations'];

--- a/classes/session_form.php
+++ b/classes/session_form.php
@@ -77,6 +77,12 @@ class mod_facetoface_session_form extends moodleform {
             $mform->addHelpButton('custom_room', 'room', 'facetoface');
         }
 
+        // Session visibility.
+        $choices = [0 => get_string('hide'), 1 => get_string('show')];
+        $mform->addElement('select', 'visible', get_string('sessionvisibility', 'facetoface'), $choices);
+        $mform->addHelpButton('visible', 'sessionvisibility', 'facetoface');
+        $mform->setDefault('visible', '1');
+
         $formarray  = [];
         $formarray[] = $mform->createElement('selectyesno', 'datetimeknown', get_string('sessiondatetimeknown', 'facetoface'));
         $formarray[] = $mform->createElement('static', 'datetimeknownhint', '',

--- a/db/install.xml
+++ b/db/install.xml
@@ -72,6 +72,7 @@
         <FIELD NAME="normalcost" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="The normal (non-discounted) cost of the session"/>
         <FIELD NAME="discountcost" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Discounted cost of the event"/>
         <FIELD NAME="allowcancellations" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
+        <FIELD NAME="visible" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Session visibility status"/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="20" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="timemodified" TYPE="int" LENGTH="20" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
       </FIELDS>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -891,5 +891,20 @@ function xmldb_facetoface_upgrade($oldversion=0) {
         upgrade_mod_savepoint(true, 2025072400, 'facetoface');
     }
 
+    if ($oldversion < 2025080600) {
+
+        // Define field visible to be added to facetoface_sessions
+        $table = new xmldb_table('facetoface_sessions');
+        $field = new xmldb_field('visible', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1', 'allowcancellations');
+
+        // Conditionally launch add field visible
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Face-to-face savepoint reached
+        upgrade_mod_savepoint(true, 2025080600, 'facetoface');
+    }
+
     return $result;
 }

--- a/lang/en/facetoface.php
+++ b/lang/en/facetoface.php
@@ -262,6 +262,7 @@ $string['format'] = 'Format';
 $string['full'] = 'Date is fully occupied';
 $string['goback'] = 'Go back';
 $string['guestsno'] = 'Sorry, guests are not allowed to sign up for sessions.';
+$string['hidden'] = 'Hidden';
 $string['icalendarheading'] = 'iCalendar Attachments';
 $string['import'] = 'Import';
 $string['info'] = 'Info';

--- a/lang/en/facetoface.php
+++ b/lang/en/facetoface.php
@@ -816,6 +816,9 @@ $string['venue_help'] = '**Venue** is the building the session will be held in.
 
 The **Venue** displays on the \'Sign-up\' page, the \'View all sessions\' page and in all email notifications.';
 
+$string['sessionvisibility'] = 'Session visibility';
+$string['sessionvisibility_help'] = '* Show: The session appears in the list and students can access it.
+* Hide: Access is restricted to teachers and other users with the capability to edit sessions.';
 $string['waitlistedmessage_help'] = 'This message is sent out whenever users sign-up for a wait-listed session.';
 
 /* Face-to-face events and logging */

--- a/lib.php
+++ b/lib.php
@@ -1633,7 +1633,7 @@ function facetoface_write_activity_attendance(&$worksheet, $startingrow, $faceto
 
     // Fast version of "facetoface_get_sessions($facetofaceid, $location)".
     $sql = "SELECT d.id as dateid, s.id, s.datetimeknown, s.capacity,
-                   s.duration, d.timestart, d.timefinish
+                   s.duration, d.timestart, d.timefinish, s.visible
               FROM {facetoface_sessions} s
               JOIN {facetoface_sessions_dates} d ON s.id = d.sessionid
               WHERE
@@ -1650,7 +1650,9 @@ function facetoface_write_activity_attendance(&$worksheet, $startingrow, $faceto
 
         $sessiontrainers = facetoface_get_trainers($session->id);
 
-        if ($session->datetimeknown) {
+        if (!$session->visible) {
+            $status = get_string('hidden', 'facetoface');
+        } else if ($session->datetimeknown) {
             if ($session->timestart < $timenow) {
                 $status = get_string('sessionover', 'facetoface');
             } else {

--- a/lib.php
+++ b/lib.php
@@ -2742,6 +2742,8 @@ function facetoface_cm_info_view(cm_info $coursemodule) {
     }
     // Can view attendees.
     $viewattendees = has_capability('mod/facetoface:viewattendees', $contextmodule);
+    // Can edit sessions.
+    $editsessions = has_capability('mod/facetoface:editsessions', $contextmodule);
     // Can see "view all sessions" link even if activity is hidden/currently unavailable.
     $iseditor = has_any_capability([
         'mod/facetoface:viewattendees', 'mod/facetoface:editsessions',
@@ -2851,6 +2853,10 @@ function facetoface_cm_info_view(cm_info $coursemodule) {
             $futuresessions = [];
 
             foreach ($sessions as $session) {
+                if ($session->visible == '0' && !$editsessions) {
+                    continue;
+                }
+
                 if (!facetoface_session_has_capacity($session, $contextmodule, MDL_F2F_STATUS_WAITLISTED)
                     && !$session->allowoverbook) {
                     continue;

--- a/renderer.php
+++ b/renderer.php
@@ -213,7 +213,7 @@ class mod_facetoface_renderer extends plugin_renderer_base {
             $row = new html_table_row($sessionrow);
 
             // Set the CSS class for the row.
-            if ($sessionstarted) {
+            if ($sessionstarted || !$session->visible) {
                 $row->attributes = ['class' => 'dimmed_text'];
             } else if ($isbookedsession) {
                 $row->attributes = ['class' => 'highlight'];

--- a/renderer.php
+++ b/renderer.php
@@ -138,7 +138,9 @@ class mod_facetoface_renderer extends plugin_renderer_base {
 
             // Status.
             $status  = get_string('bookingopen', 'facetoface');
-            if ($session->datetimeknown
+            if (!$session->visible) {
+                $status = get_string('hidden', 'facetoface');
+            } else if ($session->datetimeknown
                 && facetoface_has_session_started($session, $timenow)
                 && facetoface_is_session_in_progress($session, $timenow)) {
                 $status = get_string('sessioninprogress', 'facetoface');

--- a/sessions.php
+++ b/sessions.php
@@ -188,6 +188,7 @@ if ($fromform = $mform->get_data()) { // Form submitted.
 
     $todb = new stdClass();
     $todb->facetoface = $facetoface->id;
+    $todb->visible = $fromform->visible;
     $todb->datetimeknown = $fromform->datetimeknown;
     $todb->capacity = $fromform->capacity;
     $todb->allowoverbook = $fromform->allowoverbook;
@@ -317,6 +318,7 @@ if ($fromform = $mform->get_data()) { // Form submitted.
         $session->id
     );
 
+    $toform->visible = $session->visible;
     $toform->datetimeknown = (1 == $session->datetimeknown);
     $toform->capacity = $session->capacity;
     $toform->allowoverbook = $session->allowoverbook;

--- a/tests/behat/session.feature
+++ b/tests/behat/session.feature
@@ -1,0 +1,51 @@
+@mod @mod_facetoface
+Feature: A session can be hidden to specific users
+  In order to control which sessions students can see
+  As a teacher
+  I need to be able to hide and show sessions
+
+  Background:
+    Given the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | 1        | teacher1@example.com |
+      | student1 | Student   | 1        | student@example.com  |
+    And the following "courses" exist:
+      | fullname | shortname | format |
+      | Course 1 | C1        | weeks  |
+    And the following "course enrolments" exist:
+      | user     | course | role           |
+      | teacher1 | C1     | editingteacher |
+      | student1 | C1     | student        |
+    And the following "activity" exists:
+      | activity | facetoface |
+      | course   | C1         |
+      | name     | Session 1  |
+      | display  | 1          |
+
+  @javascript
+  Scenario: Create a visible session for students
+    Given the following "mod_facetoface > sessions" exist:
+      | facetoface | timestart                   | timefinish                           | visible |
+      | Session 1  | ##first day of next month## | ##first day of next month + 1 hour## | 1       |
+    When I am on the "C1" "Course" page logged in as "student1"
+    Then I should see "Sign-up"
+    And I follow "View all sessions"
+    Then I should see "Sign-up"
+
+  Scenario: Create a hidden session for students
+    Given the following "mod_facetoface > sessions" exist:
+      | facetoface | timestart                   | timefinish                           | visible |
+      | Session 1  | ##first day of next month## | ##first day of next month + 1 hour## | 0       |
+    When I am on the "C1" "Course" page logged in as "student1"
+    Then I should not see "Sign-up"
+    And I follow "View all sessions"
+    Then I should see "No upcoming sessions"
+
+  Scenario: Ensure teachers can still see hidden sessions
+    Given the following "mod_facetoface > sessions" exist:
+      | facetoface | timestart                   | timefinish                           | visible |
+      | Session 1  | ##first day of next month## | ##first day of next month + 1 hour## | 0       |
+    When I am on the "C1" "Course" page logged in as "teacher1"
+    Then I should see "Sign-up"
+    And I follow "View all sessions"
+    Then I should see "Sign-up"

--- a/version.php
+++ b/version.php
@@ -30,8 +30,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025072400;
-$plugin->release   = 2025072400;
+$plugin->version   = 2025080600;
+$plugin->release   = 2025080600;
 $plugin->requires  = 2023100900;  // Requires 4.3.
 $plugin->component = 'mod_facetoface';
 $plugin->maturity  = MATURITY_STABLE;

--- a/view.php
+++ b/view.php
@@ -171,6 +171,9 @@ function print_session_list($courseid, $facetoface, $location) {
 
     if ($sessions = facetoface_get_sessions($facetoface->id, $location) ) {
         foreach ($sessions as $session) {
+            if ($session->visible == '0' && !$editsessions) {
+                continue;
+            }
             $sessionstarted = false;
             $sessionfull = false;
             $sessionwaitlisted = false;


### PR DESCRIPTION
**Description:** Cherry-picked client QA'd commits from the `f2f_enhancements_combined_squashed` branch:


## Conflicts

```
❯ git cherry-pick ad72152baa7c 1c0f14579a50 40c4369e3ea7
Auto-merging classes/external/create_session.php
Auto-merging db/install.xml
Auto-merging db/upgrade.php
CONFLICT (content): Merge conflict in db/upgrade.php
Auto-merging lang/en/facetoface.php
Auto-merging lib.php
Auto-merging version.php
CONFLICT (content): Merge conflict in version.php
error: could not apply ad72152... Issue #206: Session visibility (#218)
```

`version.php`
```php
<<<<<<< HEAD
$plugin->version   = 2025080600;
$plugin->release   = 2025080600;
=======
$plugin->version   = 2025052303;
$plugin->release   = 2025052303;
>>>>>>> ad72152 (Issue #206: Session visibility (#218))
```

`db/upgrade.php`
```php
<<<<<<< HEAD
    if ($oldversion < 2025072400) {

        // Define field visibleto to be added to facetoface_session_field
        $table = new xmldb_table('facetoface_session_field');
        $field = new xmldb_field(
            'visibleto',
            XMLDB_TYPE_INTEGER,
            '1',
            null,
            XMLDB_NOTNULL,
            null,
            MDL_F2F_FIELD_VISIBLETOALL,
            'showinsummary'
        );

        // Conditionally launch add field visibleto.
        if (!$dbman->field_exists($table, $field)) {
            $dbman->add_field($table, $field);

            // Get all existing records and set visibleto based on showinsummary value.
            $recordset = $DB->get_recordset('facetoface_session_field');
            foreach ($recordset as $record) {
                $record->visibleto = empty($record->showinsummary) ? MDL_F2F_FIELD_NOTVISIBLE : MDL_F2F_FIELD_VISIBLETOALL;
                $DB->update_record('facetoface_session_field', $record);
            }
            $recordset->close;
        }

        // Face-to-face savepoint reached
        upgrade_mod_savepoint(true, 2025072400, 'facetoface');
=======
    if ($oldversion < 2025052303) {

        // Define field visible to be added to facetoface_sessions
        $table = new xmldb_table('facetoface_sessions');
        $field = new xmldb_field('visible', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1', 'allowcancellations');

        // Conditionally launch add field visible
        if (!$dbman->field_exists($table, $field)) {
            $dbman->add_field($table, $field);
        }

        // Face-to-face savepoint reached
        upgrade_mod_savepoint(true, 2025052303, 'facetoface');
>>>>>>> ad72152 (Issue #206: Session visibility (#218))
    }

    return $result;
}
```

## Resolution

Update version numbers in the conflicted files to `2025080600`

## Upgrade

Successfully upgraded from previous version:

```
-->mod_facetoface
++ 2025080600: Success (1.30 seconds) ++
++ Success (1.70 seconds) ++
-->upgrade_noncore()
```