### PR TITLE
 Issue #207: Add session visibility column to session entity 

### DIFF
--- a/classes/reportbuilder/local/entities/session.php
+++ b/classes/reportbuilder/local/entities/session.php
@@ -215,6 +215,18 @@ class session extends base {
         }
         $columns[] = $column;
 
+        // Column session visibility.
+        $columns[] = (new column(
+            'visibility',
+            new lang_string('sessionvisibility', 'mod_facetoface'),
+            $this->get_entity_name()
+        ))
+            ->add_joins($this->get_joins())
+            ->set_type(column::TYPE_BOOLEAN)
+            ->add_field("{$session}.visible")
+            ->set_is_sortable(true)
+            ->add_callback([format::class, 'boolean_as_text']);
+
         // Column session status.
         $columns[] = (new column(
             'status',
@@ -324,6 +336,17 @@ class session extends base {
         ))
             ->add_joins($this->get_joins())
             ->set_field_sql("CASE WHEN ({$bookingsquery} >= {$session}.capacity) THEN 1 ELSE 0 END");
+
+
+        // Filter session visibility.
+        $filters[] = (new filter(
+            boolean_select::class,
+            'visible',
+            new lang_string('sessionvisibility', 'mod_facetoface'),
+            $this->get_entity_name(),
+            "{$session}.visible"
+        ))
+            ->add_joins($this->get_joins());
 
         foreach ($this->customfields as $field) {
             $fieldalias = $field->alias;

--- a/tests/reportbuilder/datasource/facetoface_test.php
+++ b/tests/reportbuilder/datasource/facetoface_test.php
@@ -75,6 +75,7 @@ final class facetoface_test extends core_reportbuilder_testcase {
             'normalcost' => '111',
             'discountcost' => '11',
             'allowcancellations' => '0',
+            'visible' => '1',
             'sessiondates' => [
                 ['timestart' => $now + 1 * DAYSECS, 'timefinish' => $now + 2 * DAYSECS],
             ],
@@ -94,6 +95,8 @@ final class facetoface_test extends core_reportbuilder_testcase {
         $this->rbgenerator->create_column(['reportid' => $report->get('id'), 'uniqueidentifier' => 'facetoface:name']);
         // Add session date start column to the report.
         $this->rbgenerator->create_column(['reportid' => $report->get('id'), 'uniqueidentifier' => 'session_date:datestart']);
+        // Add session visibility column to the report.
+        $this->rbgenerator->create_column(['reportid' => $report->get('id'), 'uniqueidentifier' => 'session:visibility']);
         // Add user fullname column to the report.
         $this->rbgenerator->create_column(['reportid' => $report->get('id'), 'uniqueidentifier' => 'user:fullname']);
 
@@ -106,6 +109,7 @@ final class facetoface_test extends core_reportbuilder_testcase {
             'Test course', // Course fullname.
             'My facetoface', // Facetoface name.
             userdate($now + 1 * DAYSECS, $dateformat), // Session start date.
+            'Yes', // Session visibility.
             fullname($student), // User full name.
         ], $contentrow);
     }


### PR DESCRIPTION
> [!CAUTION]
> This branch is based off of [tests/reportbuilder-add-tests](https://github.com/catalyst/moodle-mod_facetoface/tree/tests/reportbuilder-add-tests). PR https://github.com/catalyst/moodle-mod_facetoface/pull/247 needs to be merged first

**Description:** Add session visibility column. This uses the same language string type as the core course entity visible column:

<img width="774" height="303" alt="image" src="https://github.com/user-attachments/assets/a71f50cf-a2e5-4183-9188-be4c74c8bf04" />