### PR TITLE
Fix `get_bookings_query` to not retrieve cancelled bookings

### DIFF
--- a/classes/reportbuilder/local/helpers/facetoface.php
+++ b/classes/reportbuilder/local/helpers/facetoface.php
@@ -18,6 +18,8 @@ declare(strict_types=1);
 
 namespace mod_facetoface\reportbuilder\local\helpers;
 
+require_once("$CFG->dirroot/mod/facetoface/lib.php");
+
 /**
  * Helpers for the facetoface RB entities
  *
@@ -35,10 +37,10 @@ class facetoface {
      */
     public static function get_bookings_query(string $tablealias): string {
         $excludestatuses = [
-            10,
-            30,
-            40,
-            60,
+            MDL_F2F_STATUS_USER_CANCELLED,
+            MDL_F2F_STATUS_DECLINED,
+            MDL_F2F_STATUS_REQUESTED,
+            MDL_F2F_STATUS_WAITLISTED,
         ];
         $excludesql = 'NOT IN (' . implode(',', $excludestatuses) . ')';
 

--- a/classes/reportbuilder/local/helpers/facetoface.php
+++ b/classes/reportbuilder/local/helpers/facetoface.php
@@ -35,7 +35,7 @@ class facetoface {
      */
     public static function get_bookings_query(string $tablealias): string {
         $excludestatuses = [
-            20,
+            10,
             30,
             40,
             60,


### PR DESCRIPTION
**Description:** This Reportbuilder helper should only retrieve not cancelled bookings. However, the `$excludedstatuses` array doesn't include the `USER_CANCELLED` status, so it is still getting cancelled bookings.

This means the report will misattribute cancelled bookings as actual bookings - the `Seats booked` and `Booked / Capacity` session entity columns will be incorrect. 

https://github.com/catalyst/moodle-mod_facetoface/blob/97b428577bbc93cbfd74627b8a8fe4e0ebfc313c/lib.php#L79

https://github.com/catalyst/moodle-mod_facetoface/blob/97b428577bbc93cbfd74627b8a8fe4e0ebfc313c/classes/reportbuilder/local/helpers/facetoface.php#L30-L59

The code mistakenly has status `20` instead of `10`. This PR fixes this.

We also now use the constant variables instead of their values.