### PR TITLE
Reportbuilder fixes

### DIFF
--- a/classes/reportbuilder/local/entities/session.php
+++ b/classes/reportbuilder/local/entities/session.php
@@ -120,15 +120,9 @@ class session extends base {
             $this->get_entity_name()
         ))
             ->add_joins($this->get_joins())
-            ->add_join("LEFT JOIN {modules} m ON m.name = 'facetoface'")
-            ->add_join("
-                LEFT JOIN {course_modules} cm
-                       ON {$session}.facetoface = cm.instance AND cm.course = {$coursealias}.id AND cm.module = m.id
-            ")
             ->set_type(column::TYPE_LONGTEXT)
             ->add_field($detailsfieldsql, 'details')
             ->add_field("{$session}.facetoface", 'facetofaceid')
-            ->add_field('cm.id')
             ->set_is_sortable(false);
 
         // Column capacity.

--- a/classes/reportbuilder/local/entities/session.php
+++ b/classes/reportbuilder/local/entities/session.php
@@ -246,6 +246,17 @@ class session extends base {
                 ->set_type(column::TYPE_TEXT);
         }
 
+        // Column ID.
+        $columns[] = (new column(
+            'id',
+            new lang_string('sessionid', 'mod_facetoface'),
+            $this->get_entity_name()
+        ))
+            ->add_joins($this->get_joins())
+            ->set_type(column::TYPE_INTEGER)
+            ->add_field("{$session}.id")
+            ->set_is_sortable(true);
+
         return $columns;
     }
 
@@ -354,6 +365,16 @@ class session extends base {
                 ->add_joins($this->get_joins())
                 ->add_join($this->get_custom_field_join($field));
         }
+
+        // Filter capacity.
+        $filters[] = (new filter(
+            number::class,
+            'sessionid',
+            new lang_string('sessionid', 'mod_facetoface'),
+            $this->get_entity_name(),
+            "{$session}.id"
+        ))
+            ->add_joins($this->get_joins());
 
         return $filters;
     }

--- a/lang/en/facetoface.php
+++ b/lang/en/facetoface.php
@@ -394,6 +394,7 @@ $string['sessiondatetime'] = 'Session date/time';
 $string['sessiondatetimeknown'] = 'Session date/time known';
 $string['sessionfinishtime'] = 'Session finish time';
 $string['sessionfinished'] = 'Finished';
+$string['sessionid'] = 'Session ID number';
 $string['sessioninprogress'] = 'Session in progress';
 $string['sessionisfull'] = 'This session is now full. You will need to pick another time or talk to the instructor.';
 $string['sessionover'] = 'session over';


### PR DESCRIPTION
**Description:** 

1. Add Session ID column as this is typically the only way to identify a session besides time or description
2. Remove unneed JOINS on the details column of the session entity. Doesn't need to make reference to modules or course modules - it just needs to display the details column from `mdl_facetoface_sessions`