### PR TITLE
Send confirmation email

### DIFF
--- a/signup.php
+++ b/signup.php
@@ -154,7 +154,7 @@ if ($fromform = $mform->get_data()) { // Form submitted.
                 $fromform->notificationtype,
                 $statuscode,
                 false,
-                false
+                true
             )) {
                 // Logging and events trigger.
                 $params = [


### PR DESCRIPTION
With the value set to false we do not get course booking notification emails sent through. Changing the value to `true` changes this default behavior and matches the default function parameter.

Other MR: https://github.com/catalyst/moodle-mod_facetoface/pull/261