### PR TITLE
Fix schema alignment issues #259

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -135,7 +135,7 @@
         <FIELD NAME="defaultvalue" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="isfilter" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Whether or not this field is a filter on the Training Calendar"/>
         <FIELD NAME="showinsummary" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Whether or not to show this field in attendance exports and lists of sessions"/>
-        <FIELD NAME="visibleto" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Whether or not to show this field in lists of sessions"/>
+        <FIELD NAME="visibleto" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="2" SEQUENCE="false" COMMENT="Whether or not to show this field in lists of sessions"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -906,5 +906,27 @@ function xmldb_facetoface_upgrade($oldversion=0) {
         upgrade_mod_savepoint(true, 2025080600, 'facetoface');
     }
 
+    if ($oldversion < 2025103000) {
+
+        // Changing the default of field visibleto on table facetoface_session_field to 2.
+        $table = new xmldb_table('facetoface_session_field');
+        $field = new xmldb_field(
+            'visibleto',
+            XMLDB_TYPE_INTEGER,
+            '1',
+            null,
+            XMLDB_NOTNULL,
+            null,
+            MDL_F2F_FIELD_VISIBLETOALL,
+            'showinsummary'
+        );
+
+        // Launch change of default for field visibleto.
+        $dbman->change_field_default($table, $field);
+
+        // Facetoface savepoint reached.
+        upgrade_mod_savepoint(true, 2025103000, 'facetoface');
+    }
+
     return $result;
 }

--- a/version.php
+++ b/version.php
@@ -30,8 +30,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025081801;
-$plugin->release   = 2025081801;
+$plugin->version   = 2025103000;
+$plugin->release   = 2025103000;
 $plugin->requires  = 2023100900;  // Requires 4.3.
 $plugin->component = 'mod_facetoface';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
After speaking with @djarran the default should be 2. I updated install.xml and used XMLDB editor to generate the upgrade script (modified to include MDL_F2F_FIELD_VISIBLETOALL) for users who installed the plugin after the patch. 

Closes #259 