### PR TITLE
RB: Filter out historical signup statuses

### DIFF
--- a/classes/reportbuilder/datasource/facetofaces.php
+++ b/classes/reportbuilder/datasource/facetofaces.php
@@ -84,6 +84,7 @@ class facetofaces extends datasource {
         $attendeestatusentityjoin = "
             LEFT JOIN {facetoface_signups_status} {$attendeestatus}
             ON {$attendeestatus}.signupid = {$attendee}.id
+            AND {$attendeestatus}.superceded = 0
         ";
         $attendeeentity->add_joins([$facetofacejoin, $sessionjoin, $attendeeentityjoin, $attendeestatusentityjoin]);
         $this->add_entity($attendeeentity);


### PR DESCRIPTION
I can see two potential solutions here:
1. Filter out records with superceded set to 1 by default. With this approach, historical records for the signups status table will never be displayed in RB.
2. Add a new column "superceded" to RB which could be used to filter out historical records AND would allow building reports on the historical records if needed.

I consider option 1 to be a bug fix, while 2 is more like a further enhancement that could be done later if someone would want to sponsor this. Hence, this PR implements 1.

PS: This issue is present in MWP Appointments as well, see https://moodle.atlassian.net/browse/WP-5731