### PR TITLE
Update facetoface.php - fix default messages templates

### DIFF
--- a/lang/en/facetoface.php
+++ b/lang/en/facetoface.php
@@ -455,10 +455,6 @@ Course:   [facetofacename]
 Duration:   [duration]
 Date(s):
 [alldates]
-
-Location:   [session:location]
-Venue:   [session:venue]
-Room:   [session:room]
 ';
 $string['setting:defaultcancellationsubject'] = 'Default subject line for cancellation emails.';
 $string['setting:defaultcancellationsubject_caption'] = 'Cancellation subject';
@@ -484,10 +480,6 @@ Cost:   [cost]
 Duration:    [duration]
 Date(s):
 [alldates]
-
-Location:   [session:location]
-Venue:   [session:venue]
-Room:   [session:room]
 
 ***Please arrive ten minutes before the course starts***
 
@@ -524,10 +516,6 @@ Duration:   [duration]
 Date(s):
 [alldates]
 
-Location:   [session:location]
-Venue:   [session:venue]
-Room:   [session:room]
-
 ***Please arrive ten minutes before the course starts***
 
 To re-schedule or cancel your booking
@@ -547,10 +535,6 @@ Duration:   [duration]
 Date(s):
 [alldates]
 
-Location:   [session:location]
-Venue:   [session:venue]
-Room:   [session:room]
-
 Please follow the link below to approve the request:
 [attendeeslink]#unapproved
 
@@ -566,10 +550,6 @@ Cost:   [cost]
 Duration:   [duration]
 Date(s):
 [alldates]
-
-Location:   [session:location]
-Venue:   [session:venue]
-Room:   [session:room]
 ';
 $string['setting:defaultrequestsubjectdefault'] = 'Course booking request: [facetofacename], [starttime]-[finishtime]';
 $string['setting:defaultvalue'] = 'Default value';
@@ -578,7 +558,6 @@ $string['setting:defaultwaitlistedmessage_caption'] = 'Wait-listed message';
 $string['setting:defaultwaitlistedmessagedefault'] = 'This is to advise that you have been added to the waitlist for:
 
 Course:   [facetofacename]
-Location:  [session:location]
 Participant:   [firstname] [lastname]
 
 ***Please note this is not a course booking confirmation***


### PR DESCRIPTION
The current message templates include the `venue`, `location `and/or `room `fields for the sessions, but those fields **are not included in the plugin by default anymore**. They need to be added as custom session fields if one wants to use them.

Unless admins create them, update the local language packs or have users (teachers, managers) remove those from each and every F2F session instance by updating the notification messages, the emails sent will contain those and display meaningless lines (like in issue #105).

This is more problematic when the plugin is used in other languages, as the expressions for those placeholders are not included in the language pack. So either the EN custom fields are created. which might cause confusion for users, or some other workaround is needed to solve this.

Removing those lines from the default message templates could solve this issue.