### PR TITLE
Add new sessiondateshort placeholder

### DIFF
--- a/classes/session.php
+++ b/classes/session.php
@@ -32,20 +32,26 @@ class session {
      * Get a human-readable string of the dates for a session instance.
      *
      * @param \stdClass $sessiondate Object containing a start and finish time for a session.
+     * @param string $dateformat Lang string key for the date format.
      * @return string Date string. If session is only over a day, it just returns one date, otherwise it will show a range.
      *
      * @throws \moodle_exception
      */
-    public static function get_readable_session_date(\stdClass $sessiondate): string {
+    public static function get_readable_session_date(\stdClass $sessiondate, string $dateformat = 'strftimedate'): string {
         if (!isset($sessiondate->timestart) || !isset($sessiondate->timefinish)) {
             throw new \moodle_exception('error:invalidsessiondate', 'facetoface');
         }
-        $formatteddate = facetoface_format_session_times($sessiondate->timestart, $sessiondate->timefinish, null);
-        $date = $formatteddate->startdate;
+
+        $targettz = \core_date::get_user_timezone();
+        $format = get_string($dateformat, 'langconfig');
+        $date = userdate($sessiondate->timestart, $format, $targettz);
+        $enddate = userdate($sessiondate->timefinish, $format, $targettz);
+
         // If start and finish date cover multiple days, append the finishing date.
-        if ($formatteddate->startdate !== $formatteddate->enddate) {
-            $date .= ' - ' . $formatteddate->enddate;
+        if ($date !== $enddate) {
+            $date .= ' - ' . $enddate;
         }
+
         return $date;
     }
 

--- a/lang/en/facetoface.php
+++ b/lang/en/facetoface.php
@@ -359,6 +359,7 @@ $string['placeholder:firstname'] = '[firstname]';
 $string['placeholder:lastname'] = '[lastname]';
 $string['placeholder:reminderperiod'] = '[reminderperiod]';
 $string['placeholder:sessiondate'] = '[sessiondate]';
+$string['placeholder:sessiondateshort'] = '[sessiondateshort]';
 $string['placeholder:starttime'] = '[starttime]';
 $string['pluginadministration'] = 'Face-to-Face administration';
 $string['pluginname'] = 'Face-to-Face';

--- a/lib.php
+++ b/lib.php
@@ -784,6 +784,7 @@ function facetoface_email_substitutions($msg, $facetofacename, $reminderperiod, 
     if ($data->datetimeknown) {
         // Scheduled session.
         $sessiondate = \mod_facetoface\session::get_readable_session_datetime($data->sessiondates[0]);
+        $sessiondateshort = \mod_facetoface\session::get_readable_session_date($data->sessiondates[0], 'strftimedatefullshort');
         $starttime = userdate($data->sessiondates[0]->timestart, get_string('strftimetime'));
         $finishtime = userdate($data->sessiondates[0]->timefinish, get_string('strftimetime'));
 
@@ -797,6 +798,7 @@ function facetoface_email_substitutions($msg, $facetofacename, $reminderperiod, 
     } else {
         // Wait-listed session.
         $sessiondate = get_string('unknowndate', 'facetoface');
+        $sessiondateshort = get_string('unknowndate', 'facetoface');
         $alldates    = get_string('unknowndate', 'facetoface');
         $starttime   = get_string('unknowntime', 'facetoface');
         $finishtime  = get_string('unknowntime', 'facetoface');
@@ -808,6 +810,7 @@ function facetoface_email_substitutions($msg, $facetofacename, $reminderperiod, 
     $msg = str_replace(get_string('placeholder:cost', 'facetoface'), facetoface_cost($user->id, $sessionid, $data, false), $msg);
     $msg = str_replace(get_string('placeholder:alldates', 'facetoface'), $alldates, $msg);
     $msg = str_replace(get_string('placeholder:sessiondate', 'facetoface'), $sessiondate, $msg);
+    $msg = str_replace(get_string('placeholder:sessiondateshort', 'facetoface'), $sessiondateshort, $msg);
     $msg = str_replace(get_string('placeholder:starttime', 'facetoface'), $starttime, $msg);
     $msg = str_replace(get_string('placeholder:finishtime', 'facetoface'), $finishtime, $msg);
     $msg = str_replace(get_string('placeholder:duration', 'facetoface'), facetoface_format_duration($data->duration), $msg);

--- a/tests/session_test.php
+++ b/tests/session_test.php
@@ -71,6 +71,40 @@ final class session_test extends \advanced_testcase {
     }
 
     /**
+     * Data provider for test_get_readable_session_date_with_short_format.
+     */
+    public static function readable_session_date_short_provider(): array {
+        $starttime = strtotime('01-01-2030 0900');
+        $dateformat = get_string('strftimedatefullshort', 'langconfig');
+
+        return [
+            'single day' => [
+                'timefinishoffset' => 8 * HOURSECS,
+                'expectedstring' => userdate($starttime, $dateformat),
+            ],
+            'multiple days' => [
+                'timefinishoffset' => 80 * HOURSECS,
+                'expectedstring' => userdate($starttime, $dateformat) . ' - '
+                    . userdate($starttime + 80 * HOURSECS, $dateformat),
+            ],
+        ];
+    }
+
+    /**
+     * Test getting session date with a short date format.
+     *
+     * @dataProvider readable_session_date_short_provider
+     */
+    public function test_get_readable_session_date_with_short_format(int $timefinishoffset, string $expectedstring): void {
+        $date = (object) [
+            'timestart' => $this->starttime,
+            'timefinish' => $this->starttime + $timefinishoffset,
+        ];
+
+        $this->assertEquals($expectedstring, session::get_readable_session_date($date, 'strftimedatefullshort'));
+    }
+
+    /**
      * Test getting session time.
      */
     public function test_get_readable_session_time(): void {

--- a/version.php
+++ b/version.php
@@ -31,7 +31,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025121500;
+$plugin->version   = 2025121501;
 $plugin->release   = 2025121500;
 $plugin->requires  = 2023100900;  // Requires 4.3.
 $plugin->component = 'mod_facetoface';


### PR DESCRIPTION
**Description:** The `sessiondate` placeholder also includes the time:

```
10 April 2026, 11:40 AM - 11 April 2026, 11:40 AM
```

Instead of making a breaking change, we add a new optional placeholder to display the date like so:

```
Multi-day session: 15/04/26 - 16/04/26

Single-day session: 16/04/26
```

The exact string output by this placeholder depends on the environment's `strftimedatefullshort` language string. By default in Moodle, this is:

```
$string['strftimedatefullshort'] = '%d/%m/%y';
```

### Test instructions

1. Update the plugin with this patch (need to purge for new language string)
2. Create a F2F activity
3. Go to Activity > Settings > Confirmation message
4. Edit the subject and replace `sessiondate` with `sessiondateshort`
5. Create a new session with a date in the future
6. Add an attendee
7. Check emails
8. Confirm that the session date uses the new short format