### PR TITLE
Improve edit attendees page look

### DIFF
--- a/editattendees.php
+++ b/editattendees.php
@@ -197,7 +197,7 @@ $out .= html_writer::empty_tag('input', ['type' => 'hidden', 'name' => "backtoal
 $out .= html_writer::empty_tag('input', ['type' => 'hidden', 'name' => "sesskey", 'value' => sesskey()]);
 
 $table = new html_table();
-$table->attributes['class'] = "generaltable generalbox boxaligncenter";
+$table->attributes['class'] = "editattendeestable generaltable generalbox boxaligncenter";
 $cells = [];
 
 if ($facetoface->signuptype == MOD_FACETOFACE_SIGNUP_MULTIPLE) {
@@ -210,7 +210,7 @@ if ($facetoface->signuptype == MOD_FACETOFACE_SIGNUP_MULTIPLE) {
     );
     $content .= $OUTPUT->help_icon('addtoallsessions', 'facetoface');
     $cell = new html_table_cell($content);
-    $cell->attributes['colspan'] = '3';
+    $cell->colspan = '3';
     $table->data[] = new html_table_row([$cell]);
 }
 
@@ -223,8 +223,8 @@ $content = html_writer::checkbox(
 );
 $content .= $OUTPUT->help_icon('suppressemail', 'facetoface');
 $cell = new html_table_cell($content);
-$cell->attributes['id'] = 'backcell';
-$cell->attributes['colspan'] = '3';
+$cell->id = 'backcell';
+$cell->colspan = '3';
 $table->data[] = new html_table_row([$cell]);
 
 $content = html_writer::start_tag('p') . html_writer::tag(
@@ -234,24 +234,29 @@ $content = html_writer::start_tag('p') . html_writer::tag(
 ) . html_writer::end_tag('p');
 $content .= $existinguserselector->display(true);
 $cell = new html_table_cell($content);
-$cell->attributes['id'] = 'existingcell';
+$cell->attributes['class'] = 'existingcell';
 $cells[] = $cell;
-$content = html_writer::tag('div', html_writer::empty_tag(
-    'input',
-    [
-        'type' => 'submit', 'id' => 'add', 'name' => 'add', 'title' => get_string('add'),
-        'value' => $OUTPUT->larrow() . ' ' . get_string('add'),
-    ]
-), ['id' => 'addcontrols']);
-$content .= html_writer::tag('div', html_writer::empty_tag(
-    'input',
-    [
-        'type' => 'submit', 'id' => 'remove', 'name' => 'remove', 'title' => get_string('remove'),
-        'value' => $OUTPUT->rarrow() . ' ' . get_string('remove'),
-    ]
-), ['id' => 'removecontrols']);
+$content = html_writer::start_tag('p', ['class' => 'arrow_button']);
+$content .= html_writer::empty_tag('input', [
+    'type' => 'submit',
+    'class' => 'btn btn-secondary',
+    'id' => 'add',
+    'name' => 'add',
+    'title' => get_string('add'),
+    'value' => $OUTPUT->larrow() . ' ' . get_string('add'),
+]);
+$content .= html_writer::empty_tag('br');
+$content .= html_writer::empty_tag('input', [
+    'type' => 'submit',
+    'class' => 'btn btn-secondary',
+    'id' => 'remove',
+    'name' => 'remove',
+    'title' => get_string('remove'),
+    'value' => $OUTPUT->rarrow() . ' ' . get_string('remove'),
+]);
+$content .= html_writer::end_tag('p');
 $cell = new html_table_cell($content);
-$cell->attributes['id'] = 'buttonscell';
+$cell->attributes['class'] = 'buttonscell';
 $cells[] = $cell;
 $content = html_writer::start_tag('p') . html_writer::tag(
     'label',
@@ -260,7 +265,7 @@ $content = html_writer::start_tag('p') . html_writer::tag(
 ) . html_writer::end_tag('p');
 $content .= $potentialuserselector->display(true);
 $cell = new html_table_cell($content);
-$cell->attributes['id'] = 'potentialcell';
+$cell->attributes['class'] = 'potentialcell';
 $cells[] = $cell;
 $table->data[] = new html_table_row($cells);
 

--- a/styles.css
+++ b/styles.css
@@ -94,3 +94,19 @@ body#page-mod-facetoface-view div#page-content .formlocation {
 .path-mod-facetoface .table-responsive table.f2fbookingsuploadlist .c1 {
     width: auto;
 }
+
+.path-mod-facetoface .editattendeestable .existingcell,
+.path-mod-facetoface .editattendeestable .potentialcell {
+    width: 42%;
+}
+
+.path-mod-facetoface .editattendeestable .buttonscell {
+    width: 16%;
+}
+
+.path-mod-facetoface .editattendeestable .buttonscell p.arrow_button input {
+    width: auto;
+    min-width: 80%;
+    display: block;
+    margin: 0px auto;
+}

--- a/version.php
+++ b/version.php
@@ -31,8 +31,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025121504;
-$plugin->release   = 2025121504;
+$plugin->version   = 2025121505;
+$plugin->release   = 2025121505;
 $plugin->requires  = 2023100900;  // Requires 4.3.
 $plugin->component = 'mod_facetoface';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
As part of the UI improvements the edit attendees page was missed. This makes the page look more inline with core Moodle (i.e. groups add/remove users page).

| Before | After |
|------------|--------|
| <img width="1575" height="750" alt="image" src="https://github.com/user-attachments/assets/d20e71b5-64f5-437c-8a18-3a0adfea5701" /> | <img width="1582" height="803" alt="image" src="https://github.com/user-attachments/assets/30f89967-263c-4989-809e-d205c80b9e45" /> |