### PR TITLE
Fix attendance completion session date

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2916,16 +2916,27 @@ function facetoface_approve_requests($data) {
 function facetoface_take_individual_attendance($submissionid, $grading) {
     global $USER, $CFG, $DB;
 
+    require_once($CFG->dirroot . '/completion/criteria/completion_criteria.php');
+
     $timenow = time();
+
+    /*
+     * Aggregate session dates so multi-date sessions use their final finish
+     * time, and undated sessions can still update attendance grades.
+     */
     $record = $DB->get_record_sql(
-        "SELECT f.*, s.userid, fsd.timefinish, fs.datetimeknown
+        "SELECT f.*, s.userid, fs.datetimeknown, fsus.statuscode,
+                (SELECT MAX(fsd.timefinish)
+                   FROM {facetoface_sessions_dates} fsd
+                  WHERE fsd.sessionid = fs.id) AS timefinish
                                 FROM {facetoface_signups} s
                                 JOIN {facetoface_sessions} fs ON s.sessionid = fs.id
-                                JOIN {facetoface_sessions_dates} fsd ON s.sessionid = fsd.sessionid
                                 JOIN {facetoface} f ON f.id = fs.facetoface
                                 JOIN {course_modules} cm ON cm.instance = f.id
                                 JOIN {modules} m ON m.id = cm.module
-                                WHERE s.id = ? AND m.name='facetoface'",
+                           LEFT JOIN {facetoface_signups_status} fsus
+                                  ON fsus.signupid = s.id AND fsus.superceded = 0
+                                WHERE s.id = ? AND m.name = 'facetoface'",
         [$submissionid]
     );
 
@@ -2946,29 +2957,82 @@ function facetoface_take_individual_attendance($submissionid, $grading) {
         $completion = new \completion_info($course);
         $cm = get_coursemodule_from_instance('facetoface', $record->id, $course->id);
         if ($completion->is_enabled($cm)) {
-            // Update/create completion data
+            // Update/create completion data.
             $completion->update_state($cm, COMPLETION_UNKNOWN, $record->userid, false);
-            $meetscompletioncriteria = $grading >= $record->completionattendance;
-            if ($record->datetimeknown && get_config('facetoface', 'sessioncompletiondate') && $meetscompletioncriteria) {
-                $criterias = $completion->get_criteria(4); // 4 = completion_criteria_activity
-                foreach($criterias as $criterion) {
-                    if ($criterion->module == 'facetoface' && $criterion->moduleinstance == $cm->id) {
-                        // Get existing completion data, modify state, save, and update completion.
-                        $data = $completion->get_data($cm, false, $record->userid);
-                        $data->timemodified = $record->timefinish;
-                        $completion->internal_set_data($cm, $data);
-                        // Updating the completion state status to complete and marking criteria completion.
-                        $completion->update_state($cm, COMPLETION_COMPLETE, $record->userid, false);
-                        $criteriacompletion = $completion->get_user_completion($record->userid, $criterion);
-                        $criteriacompletion->mark_complete($record->timefinish);
-                        break;
-                    }
-                }
+
+            if (facetoface_use_session_completion_date($record, $completion, $cm)) {
+                facetoface_set_completion_date($completion, $cm, $record->userid, $record->timefinish);
             }
         }
     }
 
     return $result;
+}
+
+/**
+ * Whether this attendance marking should be dated by the session rather than by now.
+ *
+ * The activity is only backdated when attendance is what completed it. Checking
+ * the recorded completion state rather than re-deriving it keeps this honest
+ * when the activity also has to be viewed or graded to count as complete: those
+ * rules can leave it incomplete, and an incomplete activity has no date to set.
+ *
+ * @param stdClass $record signup joined to its facetoface, session and current status
+ * @param completion_info $completion completion for the course the activity is in
+ * @param stdClass|cm_info $cm the course module for the facetoface activity
+ * @return bool
+ */
+function facetoface_use_session_completion_date($record, $completion, $cm) {
+    if (!get_config('facetoface', 'sessioncompletiondate')) {
+        return false;
+    }
+
+    // A session whose dates are not known yet has nothing to be dated by.
+    if (empty($record->datetimeknown) || empty($record->timefinish)) {
+        return false;
+    }
+
+    // Match custom_completion::get_state(): completion is based on status code, not grade.
+    if ((int) $record->statuscode < (int) $record->completionattendance) {
+        return false;
+    }
+
+    $data = $completion->get_data($cm, false, $record->userid);
+
+    return in_array((int) $data->completionstate, [COMPLETION_COMPLETE, COMPLETION_COMPLETE_PASS], true);
+}
+
+/**
+ * Date an activity completion, and any course completion criterion built on it, by the session.
+ *
+ * Both are set. Course completion criteria are optional, and while the criteria
+ * update used to be the only place the activity date was written, courses that
+ * did not use them were left with the activity stamped at the moment attendance
+ * was taken instead of the session it was taken for. Core aggregates the course
+ * completion date from the criteria times, so the criterion has to be dated too
+ * or the course completion drifts to whenever the aggregation cron next ran.
+ *
+ * @param completion_info $completion completion for the course the activity is in
+ * @param stdClass|cm_info $cm the course module for the facetoface activity
+ * @param int $userid the user whose completion is being dated
+ * @param int $timefinish the moment the session finished
+ * @return void
+ */
+function facetoface_set_completion_date($completion, $cm, $userid, $timefinish) {
+    $data = $completion->get_data($cm, false, $userid);
+    $data->timemodified = $timefinish;
+
+    // update_state() stamps the current time when the state changes, so set the stored date directly.
+    $completion->internal_set_data($cm, $data);
+
+    foreach ($completion->get_criteria(COMPLETION_CRITERIA_TYPE_ACTIVITY) as $criterion) {
+        // moduleinstance holds the course module id, not the activity instance id.
+        if ($criterion->module === 'facetoface' && $criterion->moduleinstance == $cm->id) {
+            $criteriacompletion = $completion->get_user_completion($userid, $criterion);
+            $criteriacompletion->mark_complete($timefinish);
+            break;
+        }
+    }
 }
 
 /**

--- a/tests/session_test.php
+++ b/tests/session_test.php
@@ -684,66 +684,235 @@ It has plain text stuff in it<br />";
     }
 
     /**
-     * Tests that when marking attendance with the sessioncompletiondate setting enabled,
-     * the completion time is set to the session finish time instead of the current time.
+     * Set up a course whose facetoface activity completes on attendance.
      *
+     * @param int $completionattendance the status code attendance has to reach
+     * @param array $sessiondates timestart/timefinish pairs for the session
+     * @return array [course, facetoface, session, student]
      */
-    public function test_session_completion_date(): void {
-        global $DB;
-
-        $this->resetAfterTest();
-
-        // Enable session completion date setting.
-        set_config('sessioncompletiondate', 1, 'facetoface');
-
-        // Setup course and participants.
+    private function setup_attendance_completion(int $completionattendance, array $sessiondates): array {
         $generator = $this->getDataGenerator()->get_plugin_generator('mod_facetoface');
         $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
         $student = $this->getDataGenerator()->create_and_enrol($course, 'student');
         $facetoface = $generator->create_instance([
             'course' => $course->id,
             'completion' => COMPLETION_TRACKING_AUTOMATIC,
-            'completionattendance' => MDL_F2F_STATUS_FULLY_ATTENDED,
+            'completionattendance' => $completionattendance,
         ]);
-
-        // Create a session in the past.
-        $sessiondate = time() - WEEKSECS;
         $session = $generator->create_session([
             'facetoface' => $facetoface->id,
-            'sessiondates' => [
-                [
-                    'timestart' => $sessiondate,
-                    'timefinish' => $sessiondate + HOURSECS,
-                ],
-            ],
+            'sessiondates' => $sessiondates,
         ]);
 
-        // Sign up the student.
         facetoface_user_signup($session, $facetoface, $course, '', MDL_F2F_TEXT, MDL_F2F_STATUS_BOOKED, $student->id);
-        $signup = $DB->get_record('facetoface_signups', ['sessionid' => $session->id, 'userid' => $student->id]);
 
-        // Create activity course completion criteria.
+        return [$course, $facetoface, $session, $student];
+    }
+
+    /**
+     * Make the facetoface activity a course completion criterion.
+     *
+     * @param \stdClass $course
+     * @param \stdClass $facetoface
+     * @return void
+     */
+    private function add_activity_criterion(\stdClass $course, \stdClass $facetoface): void {
         $cm = get_coursemodule_from_instance('facetoface', $facetoface->id, $course->id);
-        $criteriadata = (object)[
+        // update_config() takes its argument by reference, so it needs a variable.
+        $criteriadata = (object) [
             'id' => $course->id,
-            'criteria_activity' => [
-                $cm->id => 1,
-            ],
+            'criteria_activity' => [$cm->id => 1],
         ];
         $criterion = new \completion_criteria_activity();
         $criterion->update_config($criteriadata);
+    }
 
-        // Mark attendance.
-        facetoface_take_individual_attendance($signup->id, MDL_F2F_STATUS_FULLY_ATTENDED);
+    /**
+     * Mark attendance the way the attendees screen and the CSV upload do.
+     *
+     * Both post through facetoface_take_attendance(), which maps the status code
+     * to a grade before recording it. Calling the individual function directly
+     * skips that mapping and so cannot reproduce what the plugin actually does.
+     *
+     * @param \stdClass $session
+     * @param \stdClass $student
+     * @param int $statuscode one of the MDL_F2F_STATUS_* attendance codes
+     * @return void
+     */
+    private function take_attendance(\stdClass $session, \stdClass $student, int $statuscode): void {
+        global $DB;
 
-        // Check completion date matches session date.
-        $cm = get_coursemodule_from_instance('facetoface', $facetoface->id);
+        $signup = $DB->get_record('facetoface_signups', ['sessionid' => $session->id, 'userid' => $student->id]);
+
+        facetoface_take_attendance((object) [
+            's' => $session->id,
+            'submissionid_' . $signup->id => $statuscode,
+        ]);
+    }
+
+    /**
+     * The completion date of the activity, as the activity completion report reads it.
+     *
+     * @param \stdClass $course
+     * @param \stdClass $facetoface
+     * @param \stdClass $student
+     * @return \stdClass
+     */
+    private function get_completion_data(\stdClass $course, \stdClass $facetoface, \stdClass $student): \stdClass {
+        $cm = get_coursemodule_from_instance('facetoface', $facetoface->id, $course->id);
         $completion = new \completion_info($course);
-        $completiondata = $completion->get_data($cm, false, $student->id);
+
+        return (object) (array) $completion->get_data($cm, false, $student->id);
+    }
+
+    /**
+     * With the setting enabled, the activity is dated by the session and not by the marking.
+     *
+     * Course completion criteria are optional, so this must work without them.
+     */
+    public function test_completion_date_uses_session_finish_without_course_criteria(): void {
+        $this->resetAfterTest();
+        $this->setAdminUser();
+        set_config('sessioncompletiondate', 1, 'facetoface');
+
+        $sessiondate = time() - WEEKSECS;
+        [$course, $facetoface, $session, $student] = $this->setup_attendance_completion(
+            MDL_F2F_STATUS_FULLY_ATTENDED,
+            [['timestart' => $sessiondate, 'timefinish' => $sessiondate + HOURSECS]]
+        );
+
+        $this->take_attendance($session, $student, MDL_F2F_STATUS_FULLY_ATTENDED);
+
+        $completiondata = $this->get_completion_data($course, $facetoface, $student);
+        $this->assertEquals(COMPLETION_COMPLETE, $completiondata->completionstate);
+        $this->assertEquals($sessiondate + HOURSECS, $completiondata->timemodified);
+    }
+
+    /**
+     * The course completion criterion is dated by the session too.
+     */
+    public function test_completion_date_uses_session_finish_with_course_criteria(): void {
+        global $DB;
+
+        $this->resetAfterTest();
+        $this->setAdminUser();
+        set_config('sessioncompletiondate', 1, 'facetoface');
+
+        $sessiondate = time() - WEEKSECS;
+        [$course, $facetoface, $session, $student] = $this->setup_attendance_completion(
+            MDL_F2F_STATUS_FULLY_ATTENDED,
+            [['timestart' => $sessiondate, 'timefinish' => $sessiondate + HOURSECS]]
+        );
+        $this->add_activity_criterion($course, $facetoface);
+
+        $this->take_attendance($session, $student, MDL_F2F_STATUS_FULLY_ATTENDED);
+
+        $completiondata = $this->get_completion_data($course, $facetoface, $student);
         $this->assertEquals($sessiondate + HOURSECS, $completiondata->timemodified);
 
-        // Check activity course completion criteria date matches session date.
         $criteria = $DB->get_record('course_completion_crit_compl', ['userid' => $student->id, 'course' => $course->id]);
         $this->assertEquals($sessiondate + HOURSECS, $criteria->timecompleted);
+    }
+
+    /**
+     * Partial attendance is backdated when partial attendance is what completes the activity.
+     *
+     * Partial attendance has status 90 but grade 50, so this guards the status
+     * code comparison.
+     */
+    public function test_completion_date_for_partially_attended_user(): void {
+        $this->resetAfterTest();
+        $this->setAdminUser();
+        set_config('sessioncompletiondate', 1, 'facetoface');
+
+        $sessiondate = time() - WEEKSECS;
+        [$course, $facetoface, $session, $student] = $this->setup_attendance_completion(
+            MDL_F2F_STATUS_PARTIALLY_ATTENDED,
+            [['timestart' => $sessiondate, 'timefinish' => $sessiondate + HOURSECS]]
+        );
+
+        $this->take_attendance($session, $student, MDL_F2F_STATUS_PARTIALLY_ATTENDED);
+
+        $completiondata = $this->get_completion_data($course, $facetoface, $student);
+        $this->assertEquals(COMPLETION_COMPLETE, $completiondata->completionstate);
+        $this->assertEquals($sessiondate + HOURSECS, $completiondata->timemodified);
+    }
+
+    /**
+     * A session held over several days is dated by the last of them.
+     */
+    public function test_completion_date_uses_the_last_day_of_a_multi_date_session(): void {
+        global $DB;
+
+        $this->resetAfterTest();
+        $this->setAdminUser();
+        set_config('sessioncompletiondate', 1, 'facetoface');
+
+        $firstday = time() - WEEKSECS;
+        $lastday = $firstday + (2 * DAYSECS);
+        [$course, $facetoface, $session, $student] = $this->setup_attendance_completion(
+            MDL_F2F_STATUS_FULLY_ATTENDED,
+            [
+                ['timestart' => $firstday, 'timefinish' => $firstday + HOURSECS],
+                ['timestart' => $firstday + DAYSECS, 'timefinish' => $firstday + DAYSECS + HOURSECS],
+                ['timestart' => $lastday, 'timefinish' => $lastday + HOURSECS],
+            ]
+        );
+        $this->add_activity_criterion($course, $facetoface);
+
+        $this->assertEquals(3, $DB->count_records('facetoface_sessions_dates', ['sessionid' => $session->id]));
+
+        $this->take_attendance($session, $student, MDL_F2F_STATUS_FULLY_ATTENDED);
+
+        $completiondata = $this->get_completion_data($course, $facetoface, $student);
+        $this->assertEquals($lastday + HOURSECS, $completiondata->timemodified);
+    }
+
+    /**
+     * A user who did not attend is neither completed nor dated by the session.
+     */
+    public function test_no_show_is_not_completed_or_backdated(): void {
+        global $DB;
+
+        $this->resetAfterTest();
+        $this->setAdminUser();
+        set_config('sessioncompletiondate', 1, 'facetoface');
+
+        $sessiondate = time() - WEEKSECS;
+        [$course, $facetoface, $session, $student] = $this->setup_attendance_completion(
+            MDL_F2F_STATUS_FULLY_ATTENDED,
+            [['timestart' => $sessiondate, 'timefinish' => $sessiondate + HOURSECS]]
+        );
+        $this->add_activity_criterion($course, $facetoface);
+
+        $this->take_attendance($session, $student, MDL_F2F_STATUS_NO_SHOW);
+
+        $completiondata = $this->get_completion_data($course, $facetoface, $student);
+        $this->assertEquals(COMPLETION_INCOMPLETE, $completiondata->completionstate);
+        $this->assertFalse(
+            $DB->record_exists('course_completion_crit_compl', ['userid' => $student->id, 'course' => $course->id])
+        );
+    }
+
+    /**
+     * With the setting off, completion is dated by the marking as it always was.
+     */
+    public function test_completion_date_is_the_marking_time_when_the_setting_is_off(): void {
+        $this->resetAfterTest();
+        $this->setAdminUser();
+        set_config('sessioncompletiondate', 0, 'facetoface');
+
+        $sessiondate = time() - WEEKSECS;
+        [$course, $facetoface, $session, $student] = $this->setup_attendance_completion(
+            MDL_F2F_STATUS_FULLY_ATTENDED,
+            [['timestart' => $sessiondate, 'timefinish' => $sessiondate + HOURSECS]]
+        );
+
+        $before = time();
+        $this->take_attendance($session, $student, MDL_F2F_STATUS_FULLY_ATTENDED);
+
+        $completiondata = $this->get_completion_data($course, $facetoface, $student);
+        $this->assertEquals(COMPLETION_COMPLETE, $completiondata->completionstate);
+        $this->assertGreaterThanOrEqual($before, $completiondata->timemodified);
     }
 }


### PR DESCRIPTION
Fixes the `sessioncompletiondate` handling when attendance completion is updated.

The completion timestamp now uses the session finish time consistently, including when:
- the course does not have activity completion criteria configured
- the user is marked partially attended
- the session has multiple date records

## Details

Previously, the completion date logic only updated the course completion criterion path, so activity completion could still be stamped with the attendance marking time.

The old check also compared the attendance grade against the required completion status. This broke partial attendance because partial attendance uses status `90` but grade `50`.

This change:
- uses the current signup status code when deciding whether attendance completed the activity
- uses the latest session finish time for multi-date sessions
- updates both activity completion and matching course completion criteria
- skips backdating when the session has no known finish date or the activity is not complete
